### PR TITLE
Fixes #92 -- exception in FindExt()

### DIFF
--- a/include/ttstr.h
+++ b/include/ttstr.h
@@ -60,7 +60,8 @@ public:
 
     // Method naming conventions are lower camel case when matching tt:: namespace functions
 
-    char*   FindExt(const char* pszExt) { return (char*) ttFindExt(m_psz, pszExt); }    // find filename extension
+    char*   FindExt(const char* pszExt) { return (char*) ttFindExt(m_psz, pszExt); } // find a specific filename extension
+    char*   FindExt() const;                                                         // find any extension
     char*   FindStr(const char* psz) { return ttStrStr(m_psz, psz); }
     char*   FindStrI(const char* psz) { return ttStrStrI(m_psz, psz); }
     char*   FindChar(char ch) { return ttStrChr(m_psz, ch); }
@@ -106,7 +107,6 @@ public:
     void    RemoveExtension();
 
     char*   FindLastSlash();    // Handles any mix of '\' and '/' in the filename
-    char*   FindExt() const;    // will return nullptr if no extension
 
     void FullPathName();
 #if defined(_WIN32)

--- a/include/ttwstr.h
+++ b/include/ttwstr.h
@@ -64,6 +64,8 @@ public:
 
     // Method naming conventions are lower camel case when matching tt:: namespace functions
 
+    wchar_t*   FindExt(const wchar_t* pszExt) { return (wchar_t*) ttFindExt(m_psz, pszExt); } // find a specific filename extension
+    wchar_t*   FindExt() const;                                                               // find any extension
     wchar_t*   FindStr(const wchar_t* psz) { return ttStrStr(m_psz, psz); }
     wchar_t*   FindStrI(const wchar_t* psz) { return ttStrStrI(m_psz, psz); }
     wchar_t*   FindChar(wchar_t ch) { return ttStrChr(m_psz, ch); }
@@ -109,7 +111,6 @@ public:
     void     RemoveExtension();
 
     wchar_t* FindLastSlash();     // Handles any mix of '\' and '/' in the filename
-    wchar_t* FindExt(const wchar_t* pszExt) { return (wchar_t*) ttFindExt(m_psz, pszExt); }    // find filename extension
 
     void FullPathName();
 

--- a/src/ttstr.cpp
+++ b/src/ttstr.cpp
@@ -67,6 +67,8 @@ void ttCStr::ChangeExtension(const char* pszExtension)
 char* ttCStr::FindExt() const
 {
     char* psz = ttStrChrR(m_psz, '.');
+    if (!psz)
+        return nullptr;
     if (psz == m_psz || *(psz - 1) == '.' || psz[1] == '\\' || psz[1] == '/')   // ignore .file, ./file, and ../file
         return nullptr;
     return psz;

--- a/src/ttwstr.cpp
+++ b/src/ttwstr.cpp
@@ -45,6 +45,16 @@ void ttCWStr::AppendFileName(const wchar_t* pszFile)
     *this += pszFile;
 }
 
+wchar_t* ttCWStr::FindExt() const
+{
+    wchar_t* psz = ttStrChrR(m_psz, '.');
+    if (!psz)
+        return nullptr;
+    if (psz == m_psz || *(psz - 1) == L'.' || psz[1] == L'\\' || psz[1] == L'/')   // ignore .file, ./file, and ../file
+        return nullptr;
+    return psz;
+}
+
 void ttCWStr::ChangeExtension(const wchar_t* pszExtension)
 {
     ttASSERT_NONEMPTY(pszExtension);


### PR DESCRIPTION
Fixes #92

### Description:
Fixes exception in ttCStr::FindExt(), puts both variants of **FindExt** next to each other, and adds **FindExt()** to the **ttCWstr** class.

