### PR TITLE
Add ttCLineFile class

### DIFF
--- a/include/ttlinefile.h
+++ b/include/ttlinefile.h
@@ -1,0 +1,99 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:      ttCLineFile
+// Purpose:   Line-oriented file class
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2019 KeyWorks Software (Ralph Walden)
+// License:   Apache License (see LICENSE)
+/////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+// Note that lines are zero-based. The first line is accessed as 0.
+
+// It's fine to call AddLine() before calling ReadFile(), however you can only call ReadFile() once.
+
+#include "../include/ttfile.h"  // ttCFile
+#include "../include/ttstr.h"   // ttCStr
+
+class ttCLineFile : public ttCHeap
+{
+public:
+    ttCLineFile();
+    ttCLineFile(HANDLE hHeap);
+
+    // Public functions
+
+    void AddLine(const char* pszLine);  // Adds to the end of the file
+    void DeleteLine(int line);
+    void InsertLine(int line, const char* pszLine);  // Insert before line
+    void ReplaceLine(int line, const char* pszLine);
+
+    int  GetLineNumber() { return m_curLine; }  // Get the current line number used by ReadLine() and GetCurLine()
+    int  GetMaxLine() { return m_cLines - 1; }  // Largest line number you can read
+    int  GetCount() const { return m_cLines; }  // Total number of lines
+    bool InRange(int pos) const { return (pos < m_cLines && m_cLines > 0); }
+
+    void Sort(int firstLine, int lastLine, int column = 0);  // sort lines into alphabetical order
+
+    bool ReadFile(const char* pszFile);
+    bool WriteFile(const char* pszFile = nullptr);  // nullptr will write to the file that was read
+
+    void SetCurLine(int line)  // sets the line to be read by ReadLine() or GetCurLine()
+    {
+        ttASSERT(InRange(line));
+        if (line < m_cLines)
+            m_curLine = line;
+    }
+
+    // Call ReadLine() to get the current line and increment the line number.
+
+    char* ReadLine()
+    {
+        if (m_curLine >= m_cLines)
+            return nullptr;
+        return m_aptrs[m_curLine++].pszLine;
+    }
+
+    operator char*() const
+    {
+        if (m_curLine >= m_cLines)
+            return nullptr;
+        return m_aptrs[m_curLine].pszLine;
+    }
+
+    char* operator[](int line) { return (line >= 0 && line < m_cLines) ? m_aptrs[line].pszLine : nullptr; }
+
+protected:
+    // Protected functions
+
+    void Initialize();
+
+    inline void swap(int pos1, int pos2)
+    {
+        LINE_PTRS pszTmp;
+        memcpy(&pszTmp, m_aptrs + pos1, sizeof(LINE_PTRS));
+        memcpy(m_aptrs + pos1, m_aptrs + pos2, sizeof(LINE_PTRS));
+        memcpy(m_aptrs + pos2, &pszTmp, sizeof(LINE_PTRS));
+    }
+    void qsortCol(int low, int high);
+
+private:
+    typedef struct
+    {
+        char* pszLine;
+        bool  bAllocated;  // true means string was allocated, false it's part of m_pbuf
+    } LINE_PTRS;
+
+    // Class members
+
+    ttCStr  m_cszReadFile;
+    ttCFile m_file;
+
+    int m_cLines;
+    int m_curLine;
+    int m_SortColumn;
+
+    int m_cAllocPtrs;
+
+    LINE_PTRS* m_aptrs;
+};

--- a/src/.srcfiles.yaml
+++ b/src/.srcfiles.yaml
@@ -24,6 +24,7 @@ Files:
     ttfiledir.cpp       # file and directory handling
     tthashpair.cpp      # ttCHashPair
     ttheap.cpp          # ttCHeap class
+    ttlinefile.cpp      # Line-oriented file class
     ttlist.cpp          # ttCList class
     ttmisc.cpp          # miscellaneous functions
     ttmultithread.cpp   # ttCMultiThrd class

--- a/src/ttlinefile.cpp
+++ b/src/ttlinefile.cpp
@@ -1,0 +1,204 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:      ttCLineFile
+// Purpose:   Line-oriented file class
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2019 KeyWorks Software (Ralph Walden)
+// License:   Apache License (see LICENSE)
+/////////////////////////////////////////////////////////////////////////////
+
+#include "pch.h"
+
+#include "../include/ttfile.h"  // ttCFile
+
+#include "../include/ttlinefile.h"  // ttCLineFile
+
+ttCLineFile::ttCLineFile()
+    : ttCHeap(true)
+{
+    Initialize();
+}
+
+ttCLineFile::ttCLineFile(HANDLE hHeap)
+    : ttCHeap(hHeap)
+{
+    Initialize();
+}
+void ttCLineFile::Initialize()
+{
+    m_curLine = 0;
+    m_cLines = 0;
+
+    m_cAllocPtrs = 256;
+    m_aptrs = (LINE_PTRS*) this->ttCalloc(m_cAllocPtrs * sizeof(LINE_PTRS));
+}
+
+void ttCLineFile::AddLine(const char* pszLine)
+{
+    if (m_cLines + 1 > m_cAllocPtrs)
+    {
+        m_cAllocPtrs += 256;
+        m_aptrs = (LINE_PTRS*) this->ttReCalloc(m_aptrs, m_cAllocPtrs * sizeof(LINE_PTRS));
+    }
+
+    m_aptrs[m_cLines].pszLine = this->ttStrDup(pszLine);
+    m_aptrs[m_cLines++].bAllocated = true;
+}
+
+void ttCLineFile::DeleteLine(int line)
+{
+    ttASSERT(line <= m_cLines);
+    if (line > m_cLines)
+        return;
+    if (m_aptrs[line].bAllocated)
+    {
+        this->ttFree(m_aptrs[line].pszLine);
+    }
+    memmove((void*) (m_aptrs + line), (void*) (m_aptrs + line + 1), (m_cLines - (line + 1)) * sizeof(LINE_PTRS));
+    --m_cLines;
+    if (m_curLine > m_cLines)
+        m_curLine = m_cLines;
+}
+
+bool ttCLineFile::ReadFile(const char* pszFile)
+{
+    if (m_file.GetBeginPosition()) {
+        // REVIEW: [KeyWorks - 09-03-2019] If we need to support this, then first we have to allocate memory for every
+        // string that is currently stored that hasn't been allocated yet.
+
+        ttMsgBox("You've already read a file into ttCLineFile");
+        return false;
+    }
+
+    if (m_file.ReadFile(pszFile))
+    {
+        while (m_file.ReadLine())
+        {
+            if (m_cLines + 1 > m_cAllocPtrs)
+            {
+                m_cAllocPtrs += 256;
+                m_aptrs = (LINE_PTRS*) this->ttReCalloc(m_aptrs, m_cAllocPtrs * sizeof(LINE_PTRS));
+            }
+            m_aptrs[m_cLines++].pszLine = (char*) m_file;
+        }
+        m_cszReadFile = pszFile;
+        return true;
+    }
+    else
+        return false;
+}
+
+bool ttCLineFile::WriteFile(const char* pszFile)
+{
+    if (!pszFile)
+        pszFile = m_cszReadFile;
+
+    ttCFile file;
+
+    for (int line = 0; line < m_cLines; ++line)
+        file.WriteEol(m_aptrs[line].pszLine);
+
+    return file.WriteFile(pszFile);
+}
+
+void ttCLineFile::InsertLine(int line, const char* pszLine)
+{
+    ttASSERT(line <= m_cLines);
+    if (line > m_cLines)
+        throw;
+
+    if (m_cLines + 1 > m_cAllocPtrs)
+    {
+        m_cAllocPtrs += 256;
+        m_aptrs = (LINE_PTRS*) this->ttReCalloc(m_aptrs, m_cAllocPtrs * sizeof(LINE_PTRS));
+    }
+
+    memmove((void*) (m_aptrs + line + 1), (void*) (m_aptrs + line), (m_cLines - line + 1) * sizeof(LINE_PTRS));
+    m_aptrs[line].pszLine = this->ttStrDup(pszLine);
+    m_aptrs[line].bAllocated = true;
+    m_cLines++;
+}
+
+void ttCLineFile::ReplaceLine(int line, const char* pszLine)
+{
+    ttASSERT(line < m_cLines);
+    if (line >= m_cLines)
+        throw;
+
+    if (m_aptrs[line].bAllocated)
+    {
+        this->ttFree(m_aptrs[line].pszLine);
+        m_aptrs[line].pszLine = this->ttStrDup(pszLine);
+    }
+    else
+    {
+        // If the new line is the same or shorter then the old line, then copy over it, otherwise duplicate it
+
+        auto cbOld = ttStrByteLen(m_aptrs[line].pszLine);
+        auto cbNew = ttStrByteLen(pszLine);
+        if (cbNew <= cbOld)
+            ttStrCpy(m_aptrs[line].pszLine, cbOld, pszLine);
+        else
+        {
+            m_aptrs[line].pszLine = this->ttStrDup(pszLine);
+            m_aptrs[line].bAllocated = true;
+        }
+    }
+}
+
+void ttCLineFile::Sort(int firstLine, int lastLine, int column)
+{
+#if defined(_DEBUG)
+    for (int itmp = firstLine; itmp <= lastLine; ++itmp)
+    {
+        if (!m_aptrs[itmp].pszLine)
+        {
+            ttFAIL("Attempt to sort a line that doesn't exist");
+            return;
+        }
+        if ((int) ttStrLen(m_aptrs[itmp].pszLine) < column)
+        {
+            ttFAIL("Column number is beyond the end of the line");
+            return;
+        }
+    }
+#endif  // _DEBUG
+
+    m_SortColumn = column;
+    qsortCol(firstLine, lastLine);
+}
+
+// Original caller must have confirmed that m_SortColumn is within the range of every string being sorted.
+
+void ttCLineFile::qsortCol(int low, int high)
+{
+    if (low >= high)
+        return;
+
+    // Do we need to sort?
+
+    int pos = high - 1;
+    while (pos >= low)
+    {
+        if (strcmp(m_aptrs[pos].pszLine + m_SortColumn, m_aptrs[pos + 1].pszLine + m_SortColumn) > 0)
+            break;
+        else
+            pos--;
+    }
+    if (pos < low)
+        return;  // it's already sorted
+
+    swap(low, (low + high) / 2);
+
+    int end = low;
+    for (pos = low + 1; pos <= high; pos++)
+    {
+        if (strcmp(m_aptrs[pos].pszLine + m_SortColumn, m_aptrs[low].pszLine + m_SortColumn) < 0)
+            swap(++end, pos);
+    }
+    swap(low, end);
+
+    if (low < end - 1)
+        qsortCol(low, end - 1);
+    if (end + 1 < high)
+        qsortCol(end + 1, high);
+}


### PR DESCRIPTION
### Adds new class

### Description:
The ttCFile class can be used to read and write line-oriented files. However, the lines must be accessed in sequence. It's somewhat difficult to go back to a line after it has been read. In addition, very few changes can be made to the lines themselves.

The ttCLineFile class can only be used for line-oriented files. It allows any line to be accessed at any time. Lines can be added, inserted, changed, deleted and sorted at any time prior to writing.

ttCLineFile keeps the initial file in memory, and creates an array of pointers to each line within that memory block. Lines that are added or inserted are allocated, and their pointers inserted into the array. Lines that are replaced will use the file's memory block if the new line is shorter then the original, or it will be allocated if it is longer.

