### PR TITLE
Replace TT_ASSERT with assert in source files

### DIFF
--- a/src/precompile/pch.h
+++ b/src/precompile/pch.h
@@ -43,3 +43,5 @@
 #include <string_view>
 
 #include "ttlibspace.h"
+
+#undef TT_ASSERT

--- a/src/ttparser.cpp
+++ b/src/ttparser.cpp
@@ -36,7 +36,7 @@ cmd::cmd(int argc, wchar_t** argv)
 
 void cmd::addOption(std::string_view name, std::string_view description)
 {
-    TT_ASSERT(!name.empty());
+    assert(!name.empty());
 
     auto popt = std::make_unique<cmd::Option>();
     popt->m_description = description;
@@ -47,7 +47,7 @@ void cmd::addOption(std::string_view name, std::string_view description)
 
 void cmd::addOption(std::string_view name, std::string_view description, size_t flags)
 {
-    TT_ASSERT(!name.empty());
+    assert(!name.empty());
 
     auto popt = std::make_unique<cmd::Option>();
     popt->m_description = description;
@@ -58,7 +58,7 @@ void cmd::addOption(std::string_view name, std::string_view description, size_t 
 
 void cmd::addOption(std::string_view name, std::string_view description, size_t flags, size_t setvalue)
 {
-    TT_ASSERT(!name.empty());
+    assert(!name.empty());
 
     auto popt = std::make_unique<cmd::Option>();
     popt->m_description = description;
@@ -72,7 +72,7 @@ void cmd::addOption(std::string_view name, std::string_view description, size_t 
 
 void cmd::addHiddenOption(std::string_view name, size_t flags, size_t setvalue)
 {
-    TT_ASSERT(!name.empty());
+    assert(!name.empty());
 
     auto popt = std::make_unique<cmd::Option>();
     popt->m_flags = flags | cmd::hidden;
@@ -115,7 +115,7 @@ cstr cmd::shortlong(std::string_view name)
 // Option can be a short name, a long name, or two combined names separated with a '|'.
 cmd::Option* cmd::findOption(std::string_view option) const
 {
-    TT_ASSERT(!option.empty());
+    assert(!option.empty());
 
     ttlib::cstr longname;
     if (auto pos = option.find('|'); !ttlib::isError(pos))
@@ -142,7 +142,7 @@ cmd::Option* cmd::findOption(std::string_view option) const
 
 bool cmd::isOption(std::string_view name) const
 {
-    TT_ASSERT(!name.empty());
+    assert(!name.empty());
 
     if (auto option = findOption(name); option)
     {
@@ -153,7 +153,7 @@ bool cmd::isOption(std::string_view name) const
 
 std::optional<ttlib::cstr> cmd::getOption(std::string_view name)
 {
-    TT_ASSERT(!name.empty());
+    assert(!name.empty());
 
     if (auto option = findOption(name); option)
     {

--- a/src/winsrc/precompile/pch.h
+++ b/src/winsrc/precompile/pch.h
@@ -27,3 +27,7 @@
 
 #include <windows.h>
 #include <stdlib.h>
+
+#include "ttlibspace.h"
+
+#undef TT_ASSERT

--- a/src/winsrc/ttthrdpool.cpp
+++ b/src/winsrc/ttthrdpool.cpp
@@ -115,7 +115,7 @@ DWORD WINAPI ttlib::PoolThread(void* pv)
                 {
                     // This catch is a last-ditch effort to keep the program from crashing. The caller should
                     // have handled exceptions in m_function().
-                    TT_ASSERT(false);
+                    assert(false);
                 }
 
                 ReleaseSemaphore(thrdInfo.hsemDone, 1, NULL);


### PR DESCRIPTION
Fixes #167

### Description:
The Windows build version of pch.h did not `#include "ttlibspace.h"`. However, in order to ensure that TT_ASSERT cannot be used in ttLib source code, I added it to pch.h followed by `#undef TT_ASSERT` to ensure it wouldn't be accidentally added again.

