### PR TITLE
Overhaul _tt(string) functionality to work with wxWidgets

### DIFF
--- a/include/ttTR.h
+++ b/include/ttTR.h
@@ -7,42 +7,98 @@
 /////////////////////////////////////////////////////////////////////////////
 
 /// @file
-/// Currently, actual translation requires wxWidgets. You can use these macros without wxWidgets, but the
-/// strings will not be translated.
+/// The _tt() macro lets you load localized strings from a STRINGTABLE resource when compiled for Windows. If you are
+/// using the wxWidgets library and you have loaded <wx/intl.h> prior to this library, then strings passed to the _tt()
+/// macro will be translated using the wxTranslations class.
 ///
-/// **_tt()** is similar to the _() macro in **wxWidgets** in that it is used to translate a string.
-/// The most significant difference is that _tt() returns **const std::string&** instead of **wxString&**. On
-/// Windows, that means you can pass **_tt()** to **std:string** and **std::string_view** without having to first
-/// convert it from a **UTF16** string to a **UTF8** string `wxString.utf8().data()`.
+/// You can setup your string id header file in a way that will load strings from the STRINGTABLE resource and either
+/// use non-localized strings, or strings translated via the xgettext system if you are using the wxWidgets library. For
+/// example:
 ///
-/// **_tt()** will only use the underlying **wxWidgets** library to translate a string once. It then stores
-/// the translation in an **std::map** and the next time a translation for that string is requested, it
-/// will return the already-translated string.
+///    #ifdef _WIN32
+///        #define IDS_CANNOT_OPEN  1024  // "Cannot open "
+///    #else
+///        constexpr auto IDS_CANNOT_OPEN = "Cannot open ";
+///    #endif
 ///
 /// If you need to change languages within the program, you must call **ttlib::clearTranslations()** to clear any
 /// previously stored translated strings.
-///
-/// Note: If you use these functions/macro, be sure to add `-k_tt -k_ttp:1,2 -kttTR` to your **xgettext**
-/// command line.
 
 #pragma once
 
+#include <map>
+#include <optional>
 #include <string>
 
 #include "ttcstr.h"
 
+namespace ttTR
+{
+    // We already have ttlib::emptystring, but it's a const and returning it causes a compiler error, so we create a
+    // non-const here to return. Note that this does provide the option of setting the string to a specific value to
+    // indicate an error, since it only gets returned if an empty string is passed, or in the case of translate(WORD
+    // id), it is returned if the resource id doesn't exists.
+
+    extern ttlib::cstr trEmpty;
+
+    class cmap : public std::map<const std::string, ttlib::cstr>
+    {
+    public:
+        std::pair<bool, const ttlib::cstr&> getValue(const std::string& key) const
+        {
+            if (auto found = find(key); found != end())
+                return { true, found->second };
+            else
+                return { false, trEmpty };
+        }
+    };
+}  // namespace ttTR
+
+extern ttTR::cmap tt_translations;
+
 namespace ttlib
 {
-    class cstr;
+#if defined(_WIN32)
+
+    /// If you use a numerical id in the _tt() macro, this will load the string from a
+    /// STRINGTABLE resource and return a pointer to the string.
+    const ttlib::cstr translate(WORD id);
+
+#endif
+
+// This is only useful if you have BOTH translated STRINGTABLE resources and xgettext translated .mo files. Otherwise, either include
+// ttTR.h and use _tt() macros or include wx/intl.h and use _() macros.
+#if defined(_WX_INTL_H_)
+    inline const ttlib::cstr& translate(const std::string& str)
+    {
+        if (auto [found, value] = tt_translations.getValue(str); found)
+            return value;
+        if (auto strTranslation = wxTranslations::Get()->GetTranslatedString(str); strTranslation->size())
+        {
+            ttlib::cstr tmp;
+            tmp.assign(strTranslation->utf8_str().data());
+            if (auto [pair, success] = tt_translations.insert({ str, std::move(tmp) }); success)
+            {
+                return pair->second;
+            }
+        }
+
+        // This should never happen, but an empty string is returned just in case...
+        return ttTR::trEmpty;
+    }
+#else
+
     /// Returns either a translated string, or the original string if no translation is available.
     const ttlib::cstr& translate(const std::string& str);
+
+#endif
 
     /// Clears all previously translated strings. Required after changing locale.
     void clearTranslations() noexcept;
 }  // namespace ttlib
 
 /// Macro that can be parsed by xgettext to add a string to translate.
-#define _tt(txt) ttlib::translate(txt)
+#define _tt(txt) ttlib::translate((txt))
 
 /// This macro can be placed around static text that you want xgettext.exe to extract for
 /// translation using the "xgettext.exe -kttTR" keyword option.

--- a/include/ttlibspace.h
+++ b/include/ttlibspace.h
@@ -362,10 +362,6 @@ namespace ttlib
     /// in ttlib::lang_info. String is converted to UTF8 before storing in Result.
     ttlib::cstr LoadStringEx(WORD id);
 
-    /// If you put an id in the _tt() macro (see ttTR.h), this will effectively call
-    /// LoadStringEx(), store the result and return a pointer to the string.
-    const ttlib::cstr translate(WORD id);
-
     /// Set the resource handle and language to use for loading resources. If hinstResource
     /// is NULL, the current executable is used. Otherwise it must be the handle returned
     /// by LoadLibrary().

--- a/src/ttTR.cpp
+++ b/src/ttTR.cpp
@@ -8,39 +8,23 @@
 
 #include "pch.h"
 
-#include <map>
-#include <optional>
-
-#if defined(_WX_DEFS_H_)
-    #include <wx/intl.h>
-#endif
-
 #include "ttTR.h"
-#include "ttcstr.h"
+
+ttTR::cmap tt_translations;
 
 namespace ttTR
 {
     ttlib::cstr trEmpty;
-
-    class cmap : public std::map<const std::string, ttlib::cstr>
-    {
-    public:
-        std::pair<bool, const ttlib::cstr&> getValue(const std::string& key) const
-        {
-            if (auto found = find(key); found != end())
-                return { true, found->second };
-            else
-                return { false, trEmpty };
-        }
-    };
 }  // namespace ttTR
 
-ttTR::cmap tt_translations;
+// This conditional is in case the module is being compiled directly instead of into a library (wxUiEditor does this)
 
-// We already have ttlib::emptystring, but it's a const and returning it causes a compiler error, so we create a
-// non-const here to return. Note that this does provide the option of setting the string to a specific value to
-// indicate an error, since it only gets returned if an empty string is passed, or in the case of translate(WORD id), it
-// is returned if the resource id doesn't exists.
+#if !defined(_WX_INTL_H_)
+
+// The _tt() macro can be used to load a string from the STRINGTABLE resource when compiled for Windows, or it can
+// specify a string when compiled for other platforms. If <wx/intl.h> has been loaded, then this function will never be
+// called. It exists for when translation is available for Windows builds, but not for other platforms and wxWidgets is
+// not available.
 
 const ttlib::cstr& ttlib::translate(const std::string& str)
 {
@@ -53,49 +37,21 @@ const ttlib::cstr& ttlib::translate(const std::string& str)
     {
         return value;
     }
-
     else
     {
-#if defined(_WX_DEFS_H_)
-        if (auto trans = wxTranslations::Get(); trans)
-        {
-            if (auto strTranslation = trans->GetTranslatedString(str); !strTranslation.empty())
-            {
-                if (auto [pair, success] = tt_translations.insert({ str, strTranslation->utf8_str().data() }, success))
-                {
-                    return pair->second;
-                }
-            }
-            else
-            {
-                // No translation available, make certain we don't try again.
-                if (auto [pair, success] = tt_translations.insert({ str, str }); success)
-                {
-                    return pair->second;
-                }
-            }
-        }
-        else
-        {
-            // No translation available, make certain we don't try again.
-            if (auto [pair, success] = tt_translations.insert({ str, str }); success)
-            {
-                return pair->second;
-            }
-        }
-#else   // !defined(_WX_DEFS_H_)
-        // Currently all that happens is the string is added without translation.
+        // Currently all that happens is the string is added without translation. Ideally, this should hook up directly
+        // to the xgettext translation system without requiring wxWidgets.
         if (auto [pair, success] = tt_translations.insert({ str, str }); success)
         {
             return pair->second;
         }
-#endif  // _WX_DEFS_H_
     }
 
-    // We only get here if the passed string ptr is null, or the unordered_map was unable to insert
-    // the string.
+    // We only get here if the passed string ptr is null, or the unordered_map was unable to insert the string.
     return ttTR::trEmpty;
 }
+
+#endif
 
 void ttlib::clearTranslations() noexcept
 {

--- a/src/winsrc/ttloadstr.cpp
+++ b/src/winsrc/ttloadstr.cpp
@@ -15,6 +15,7 @@
 #include <map>
 #include <string_view>
 
+#include "ttTR.h"     // cmap -- Function for translating strings
 #include "ttcstr.h"   // cstr -- Classes for handling zero-terminated char strings.
 #include "ttdebug.h"  // ttASSERT macros
 
@@ -111,11 +112,6 @@ bool ttlib::LoadStringEx(std::string& Result, WORD id)
 
 std::map<WORD, ttlib::cstr> tt_stringtable;
 
-namespace ttTR
-{
-    extern ttlib::cstr trEmpty;
-}
-
 using namespace ttTR;
 
 const ttlib::cstr ttlib::translate(WORD id)
@@ -135,7 +131,7 @@ const ttlib::cstr ttlib::translate(WORD id)
 
 #if !defined(NDEBUG)  // Starts debug section.
     trEmpty.Format("String Resource id %u not found", id);
-    ttFAIL_MSG(trEmpty);
+    assertm(false, trEmpty.c_str());
     trEmpty.clear();
 #endif
 


### PR DESCRIPTION
Fixes #166

### Description:
I suspect that the `_tt()` macro will be rarely used outside of KeyWorks projects since most folks won't have a tool like I use that automatically creates a string resource with both `#define` and `const char*` in the header file. Without that, it would be annoying to maintain a cross-platform header file.

Nevertheless, these changes are designed to handle the case where a project has both localized STRINGTABLE resources and localized .mo files for use by the **wxTranslations** class. It works when the ttTR.cpp is compiled directly into a wxWidgets project (wxUiEditor does that) as well as when compiled normally into ttLib. The wxWidgets version of the `translate` function has to be done inline since we never compile the library using wxWidgets. 
