### PR TITLE
ttlib::cmd command line parser

### DIFF
--- a/src/ttparser.cpp
+++ b/src/ttparser.cpp
@@ -146,6 +146,10 @@ bool cmd::isOption(std::string_view name) const
 
     if (auto option = findOption(name); option)
     {
+        if ((option->m_flags & needsarg))
+        {
+            return (option->m_result.size());
+        }
         return (!option->m_result.empty() && option->m_result.issameas("true"));
     }
     return false;
@@ -157,6 +161,10 @@ std::optional<ttlib::cstr> cmd::getOption(std::string_view name)
 
     if (auto option = findOption(name); option)
     {
+        if ((option->m_flags & needsarg) && option->m_result.empty())
+        {
+            return {};
+        }
         return { option->m_result };
     }
     return {};

--- a/src/winsrc/ttwinspace.cpp
+++ b/src/winsrc/ttwinspace.cpp
@@ -208,7 +208,7 @@ HFONT ttlib::CreateLogFont(std::string_view TypeFace, size_t point, bool Bold, b
 
 #include "ttparser.h"
 
-ttlib::cmd::cmd()
+void ttlib::cmd::WinInit()
 {
     int argc;
     auto argv = CommandLineToArgvW(GetCommandLineW(), &argc);


### PR DESCRIPTION
### Fixes #171
### Fixes #172 

### Description:
This fixes the bugs and omissions, but the `getResults()` function needs an overhaul before it's really useful.

