### PR TITLE
Ttcstr

### DIFF
--- a/include/ttcstr.h
+++ b/include/ttcstr.h
@@ -55,7 +55,35 @@ namespace ttlib
 
         cstr(const std::filesystem::directory_entry& dir) : bs(dir.path().string(), dir.path().string().size()) {}
 
-        void assignUTF16(std::wstring_view str);
+        cstr& assignUTF16(std::wstring_view str)
+        {
+            *this = utf16to8(str);
+            return *this;
+        }
+
+        /// If you pass wxWidgets::wx_str() to this function it will convert from UTF16 to
+        /// UTF8 on Windows, or copy it on other platforms
+        cstr& utf(std::wstring_view str)
+        {
+            *this = utf16to8(str);
+            return *this;
+        }
+
+        /// If you pass wxWidgets::wx_str() to this function it will convert from UTF16 to
+        /// UTF8 on Windows, or copy it on other platforms
+        cstr& utf(std::string_view str)
+        {
+            *this = str;
+            return *this;
+        }
+
+#if defined(_WIN32)
+        /// Returns a copy of the string converted to UTF16 on Windows, or a normal copy on other platforms
+        std::wstring wx_str() const { return to_utf16(); };
+#else
+        /// Returns a copy of the string converted to UTF16 on Windows, or a normal copy on other platforms
+        std::string wx_str() const { return substr(); }
+#endif  // _WIN32
 
         std::wstring to_utf16() const;
 

--- a/include/ttcview.h
+++ b/include/ttcview.h
@@ -24,6 +24,8 @@
     #error "The contents of <ttcview.h> are available only with C++17 or later."
 #endif
 
+#include "ttlibspace.h"  // ttlib namespace functions and declarations
+
 #define _TTLIB_CVIEW_AVAILABLE_
 
 #include <filesystem>

--- a/src/ttcstr.cpp
+++ b/src/ttcstr.cpp
@@ -686,12 +686,6 @@ std::wstring cstr::to_utf16() const
     return str16;
 }
 
-void cstr::assignUTF16(std::wstring_view str)
-{
-    clear();
-    ttlib::utf16to8(str, *this);
-}
-
 std::string_view cstr::subview(size_t start, size_t len) const noexcept
 {
     if (start >= size())


### PR DESCRIPTION
### Description:
This PR adds two additional functions designed to be used with the `wxString` class that is part of **wxWidgets**.

What we want to be able to do is construct a `ttlib::cstr` string from a `wxString` in a way that will automatically convert it when compiled for Windows (where `wxString` is UTF16) and copy it as a normal char* string on other platforms. The `assign` and `=` operator don't work because the compiler can't decide which constructor to use. So instead, we provide a `utf` function that works like `assign` but when handed a wide-character string, it automatically converts it to UTF8:

```c++
    ttlib::cstr mycstr;
    wxString myWxString;
        // initialize myWxString in some way

    mycstr.utf(myWxString.wx_str());
```

On Windows, `mycstr` will contain a UTF8 conversion of myWxString, and on all other platforms it will simply make a copy without needing to convert it.

The change to `assignUTF16` is just to make it consistent with the other assignment functions.

