### PR TITLE
ttTrace overhaul

### DIFF
--- a/include/ttdebug.h
+++ b/include/ttdebug.h
@@ -76,10 +76,13 @@ namespace ttlib
     constexpr const unsigned int WMP_SHOW_SCRIPT = (WM_USER + 0x205);
     constexpr const unsigned int WMP_SHOW_ERROR = (WM_USER + 0x206);
 
+    /// Used by the ttTRACE_LAUNCH() macro to launch ttTrace.exe if it isn't already running
+    constexpr const unsigned int WMP_LAUNCH_TRACE = (WM_USER + 0x250);
+
     /// Use this to send CLEAR, HIDE, or SHOW messages that don't include any text
     void wintrace(unsigned int type = WMP_CLEAR_TRACE);
 
-    /// handle to ttTrace main window (if it was running when ttTrace was called)
+    /// handle to the ttTrace main window
     extern HWND hwndTrace;
 
     /// class name of window to send trace messages to
@@ -188,10 +191,10 @@ __declspec(noreturn) void ttOOM(void);
     #define ttVERIFY(exp) (void) ((!!(exp)) || ttAssertionMsg(__FILE__, __func__, __LINE__, #exp, nullptr))
 
     /// Causes all calls to ttAssertionMsg to immediately return.
-    #define ttDISABLE_ASSERTS ttlib::allow_asserts(false)
+    #define ttDISABLE_ASSERTS() ttlib::allow_asserts(false)
 
     /// Causes ttAssertionMsg to run normally
-    #define ttENABLE_ASSERTS  ttlib::allow_asserts(true)
+    #define ttENABLE_ASSERTS()  ttlib::allow_asserts(true)
 
     /// All ttTRACE macros are automatically removed in Release builds. Call ttlib::wintrace()
     /// directly if you need tracing in a release build.
@@ -208,6 +211,10 @@ __declspec(noreturn) void ttOOM(void);
 
     /// Use this to send any of the WMP_SHOW_... or WMP_HIDE... messages.
     #define ttTRACE_FILTER(type) ttlib::wintrace(type)
+
+    /// This will try to locate the window for ttTrace.exe, and attempt to launch it if
+    /// the window is not found.
+    #define ttTRACE_LAUNCH() ttlib::wintrace(ttlib::WMP_LAUNCH_TRACE)
 
 #else  // Release build or non-Windows build
 
@@ -231,11 +238,13 @@ __declspec(noreturn) void ttOOM(void);
 
     #define ttTRACE_FILTER(type)
 
+    #define ttTRACE_LAUNCH()
+
     #define ttASSERT_NONEMPTY(ptr)
     #define ttASSERT_STRING(str)
 
-    #define ttDISABLE_ASSERTS
-    #define ttENABLE_ASSERTS
+    #define ttDISABLE_ASSERTS()
+    #define ttENABLE_ASSERTS()
 
     #define ttASSERT_HRESULT(hr, pszMsg)
     #define ttLAST_ERROR()

--- a/include/ttdebug.h
+++ b/include/ttdebug.h
@@ -184,7 +184,10 @@ __declspec(noreturn) void ttOOM(void);
     // This still executes the expression in non-DEBUG builds, it just doesn't check the result.
     #define ttVERIFY(exp) (void) ((!!(exp)) || ttAssertionMsg(__FILE__, __func__, __LINE__, #exp, nullptr))
 
-    /// All ttTRACE macros are automatically removed in Release builds. Call ttlib::wintrace
+    #define ttDISABLE_ASSERTS ttSetAsserts(true)
+    #define ttENABLE_ASSERTS  ttSetAsserts(false)
+
+    /// All ttTRACE macros are automatically removed in Release builds. Call ttlib::wintrace()
     /// directly if you need tracing in a release build.
     #define ttTRACE(msg)         ttlib::wintrace(msg, ttlib::WMP_TRACE_GENERAL)
     #define ttTRACE_ERROR(msg)   ttlib::wintrace(msg, ttlib::WMP_TRACE_ERROR)
@@ -194,10 +197,11 @@ __declspec(noreturn) void ttOOM(void);
     #define ttTRACE_PROPERTY(msg) ttlib::wintrace(msg, ttlib::WMP_TRACE_PROPERTY)
     #define ttTRACE_SCRIPT(msg)   ttlib::wintrace(msg, ttlib::WMP_TRACE_SCRIPT)
 
-    #define ttTRACE_CLEAR() ttlib::wintrace(ttlib::WMP_CLEAR_TRACE);
+    #define ttTRACE_CLEAR()    ttlib::wintrace(ttlib::WMP_CLEAR_TRACE)
+    #define ttTRACE_TITLE(msg) ttlib::wintrace(msg, ttlib::WMP_SET_TITLE)
 
-    #define ttDISABLE_ASSERTS ttSetAsserts(true)
-    #define ttENABLE_ASSERTS  ttSetAsserts(false)
+    /// Use this to send any of the WMP_SHOW_... or WMP_HIDE... messages.
+    #define ttTRACE_FILTER(type) ttlib::wintrace(type)
 
 #else  // not _DEBUG
 
@@ -217,6 +221,9 @@ __declspec(noreturn) void ttOOM(void);
     #define ttTRACE_SCRIPT(msg)
 
     #define ttTRACE_CLEAR()
+    #define ttTRACE_TITLE(msg)
+
+    #define ttTRACE_FILTER(type)
 
     #define ttASSERT_NONEMPTY(ptr)
     #define ttASSERT_STRING(str)

--- a/src/winsrc/ttdebug.cpp
+++ b/src/winsrc/ttdebug.cpp
@@ -167,7 +167,10 @@ void ttlib::wintrace(const std::string& msg, unsigned int type)
         throw std::invalid_argument("wintrace msg must not exceed 4092 bytes");
 
     std::strcpy(ttdbg::g_pszTraceMap, msg.c_str());
-    std::strcat(ttdbg::g_pszTraceMap, "\n");
+
+    // For compatability with KeyView, ttTrace always add it's own \n character after receiving a WMP_GENERAL_MSG
+    if (type != WMP_TRACE_GENERAL)
+        std::strcat(ttdbg::g_pszTraceMap, "\n");
 
     SendMessageW(ttlib::hwndTrace, type, 0, 0);
 


### PR DESCRIPTION
#173 # Description:
This PR overhauls the **ttTrace** functionality by making it more efficient when **ttTrace** isn't running and to add the ability to launch `ttTrace.exe` if it isn't already running.

Previously the `wintrace()` call would initialize the window handle, and if **ttTrace** was not running then every time `wintrace()` was called it would check to see if more than 5 seconds had passed, and if so, it would look for it again. That meant that if the caller launched `ttTrace.exe`, all calls to `wintrace()` would not display their strings until 5 seconds had elapsed.

The PR adds a `ttTRACE_LAUNCH()` macro which will first look for the ttTrace.exe window, and if not found, it will launch it and set a flag so that the next call to `wintrace()` will search for the ttTrace window (which gives the ttTrace app time to create it's window).


