### PR TITLE
Add new system for retrieving localized strings

### DIFF
--- a/include/ttstrings.h
+++ b/include/ttstrings.h
@@ -1,0 +1,110 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Functions accessing translatable strings
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2020 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <map>
+#include <string>
+
+#include <ttcstr.h>   // cstr -- Classes for handling zero-terminated char strings.
+#include <ttcview.h>  // cview -- string_view functionality on a zero-terminated char string.
+
+/// This needs to be declared and initialized in whatever source file you use to declare all
+/// of your strings
+extern const std::map<int, const char*>* _tt_CurLanguage;
+
+inline void _ttSetCurLanguage(const std::map<int, const char*>* lang)
+{
+    _tt_CurLanguage = lang;
+}
+
+/// Looks up the translated string based on the current _tt_CurLanguage map.
+const char* _tt(int id);
+
+/// Looks up the translated string based on the current _tt_CurLanguage map.
+///
+/// Use this if you need a zero-terminated string_view
+ttlib::cview _ttv(int id);
+
+/// Looks up the translated string based on the current _tt_CurLanguage map.
+///
+/// Use this if you need to use << or + operators to add to the string.
+ttlib::cstr _ttc(int id);
+
+#if defined(_WIN32)
+
+/// Looks up the translated string based on the current _tt_CurLanguage map.
+///
+/// Use this to pass the string to the wxString class in wxWidgets. On Windows,
+/// it returns a UTF16 converted string. On non-Windows, it simply returns a const char*.
+std::wstring _ttwx(int id);
+
+#else
+
+/// Looks up the translated string based on the current _tt_CurLanguage map.
+///
+/// Use this to pass the string to the wxString class in wxWidgets. On Windows,
+/// it returns a UTF16 converted string. On non-Windows, it simply returns a const char*.
+inline const char* _ttwx(int id)
+{
+    return _tt(id);
+}
+
+#endif  // _WIN32
+
+/////////////////////////////////////////////////////////////////////
+//
+// The following can be used if you prefer to perform the lookup using an english string rather than an id. You must
+// have declared and initialized a _tt_english pointer that points to your std:map pair of ids and english strings. You
+// can then call _ttSetCurLanguage to point to a different language and all of the calls below will return the matching
+// translation.
+//
+// Note that lookup is considerable slower than using an ID, and is more error prone -- if the string parameter you pass
+// does not match exactly the string in _tt_english, then you will not get a translated string.
+//
+/////////////////////////////////////////////////////////////////////
+
+/// If you want to use _tt(const char*) then you must declare and initialize this variable in
+/// whatever source file you use to declare all of your strings
+extern const std::map<int, const char*>* _tt_english;
+
+/// This will lookup the string in _tt_english and use the matching id to lookup the string
+/// in whatever _tt_CurLanguage is pointing to.
+const char* _tt(const char* str);
+
+/// This will lookup the string in _tt_english and use the matching id to lookup the string
+/// in whatever _tt_CurLanguage is pointing to.
+///
+/// Use this if you need a zero-terminated string_view
+ttlib::cview _ttv(const char* str);
+
+/// This will lookup the string in _tt_english and use the matching id to lookup the string
+/// in whatever _tt_CurLanguage is pointing to.
+///
+/// Use this if you need to use << or + operators to add to the string.
+ttlib::cstr _ttc(const char* str);
+
+#if defined(_WIN32)
+
+/// Looks up the translated string based on the current _tt_CurLanguage map.
+///
+/// Use this to pass the string to the wxString class in wxWidgets. On Windows,
+/// it returns a UTF16 converted string. On non-Windows, it simply returns a const char*.
+std::wstring _ttwx(const char* str);
+
+#else
+
+/// Looks up the translated string based on the current _tt_CurLanguage map.
+///
+/// Use this to pass the string to the wxString class in wxWidgets. On Windows,
+/// it returns a UTF16 converted string. On non-Windows, it simply returns a const char*.
+inline const char* _ttwx(const char* str)
+{
+    return _tt(str);
+}
+
+#endif  // _WIN32

--- a/src/.srcfiles.win.yaml
+++ b/src/.srcfiles.win.yaml
@@ -25,6 +25,7 @@ Files:
     ttmultistr.cpp   # ttlib::multistr, ttlib::multiview
     ttlibspace.cpp   # ttlib namespace functions
     ttparser.cpp     # Command line parser
+    ttstrings.cpp    # Class for handling zero-terminated char strings.
     tttextfile.cpp   # Classes for reading and writing text files.
 
 # Windows only files

--- a/src/.srcfiles.yaml
+++ b/src/.srcfiles.yaml
@@ -16,12 +16,13 @@ Options:
     TargetDir:  ../lib
 
 Files:
-    ttTR.cpp         # Function for translating strings
     ttconsole.cpp    # class that sets/restores console foreground color
     ttcstr.cpp       # Class for handling zero-terminated char strings.
     ttcvector.cpp    # Vector class for storing ttlib::cstr strings
     ttcview.cpp      # string_view functionality on a zero-terminated char string.
     ttenumstr.cpp    # ttEnumStr, ttEnumStr
     ttlibspace.cpp   # ttlib namespace functions
-    tttextfile.cpp   # Classes for reading and writing text files.
     ttparser.cpp     # Command line parser
+    ttstrings.cpp    # Class for handling zero-terminated char strings.
+    tttextfile.cpp   # Classes for reading and writing text files.
+    ttTR.cpp         # Function for translating strings

--- a/src/bld/clang_dbg.ninja
+++ b/src/bld/clang_dbg.ninja
@@ -48,6 +48,8 @@ build $outdir/ttlibspace.obj: compile ttlibspace.cpp | $outdir/pch.obj
 
 build $outdir/ttparser.obj: compile ttparser.cpp | $outdir/pch.obj
 
+build $outdir/ttstrings.obj: compile ttstrings.cpp | $outdir/pch.obj
+
 build $outdir/tttextfile.obj: compile tttextfile.cpp | $outdir/pch.obj
 
 build $outdir/ttdib.obj: compile winsrc/ttdib.cpp | $outdir/pch.obj
@@ -83,6 +85,7 @@ build ../lib/ttLibD.lib : lib $
   $outdir/ttmultistr.obj $
   $outdir/ttlibspace.obj $
   $outdir/ttparser.obj $
+  $outdir/ttstrings.obj $
   $outdir/tttextfile.obj $
   $outdir/ttdib.obj $
   $outdir/ttdirdlg.obj $

--- a/src/bld/clang_rel.ninja
+++ b/src/bld/clang_rel.ninja
@@ -49,6 +49,8 @@ build $outdir/ttlibspace.obj: compile ttlibspace.cpp | $outdir/pch.obj
 
 build $outdir/ttparser.obj: compile ttparser.cpp | $outdir/pch.obj
 
+build $outdir/ttstrings.obj: compile ttstrings.cpp | $outdir/pch.obj
+
 build $outdir/tttextfile.obj: compile tttextfile.cpp | $outdir/pch.obj
 
 build $outdir/ttdib.obj: compile winsrc/ttdib.cpp | $outdir/pch.obj
@@ -84,6 +86,7 @@ build ../lib/ttLib.lib : lib $
   $outdir/ttmultistr.obj $
   $outdir/ttlibspace.obj $
   $outdir/ttparser.obj $
+  $outdir/ttstrings.obj $
   $outdir/tttextfile.obj $
   $outdir/ttdib.obj $
   $outdir/ttdirdlg.obj $

--- a/src/bld/msvc_dbg.ninja
+++ b/src/bld/msvc_dbg.ninja
@@ -48,6 +48,8 @@ build $outdir/ttlibspace.obj: compile ttlibspace.cpp | $outdir/pch.obj
 
 build $outdir/ttparser.obj: compile ttparser.cpp | $outdir/pch.obj
 
+build $outdir/ttstrings.obj: compile ttstrings.cpp | $outdir/pch.obj
+
 build $outdir/tttextfile.obj: compile tttextfile.cpp | $outdir/pch.obj
 
 build $outdir/ttdib.obj: compile winsrc/ttdib.cpp | $outdir/pch.obj
@@ -83,6 +85,7 @@ build ../lib/ttLibD.lib : lib $
   $outdir/ttmultistr.obj $
   $outdir/ttlibspace.obj $
   $outdir/ttparser.obj $
+  $outdir/ttstrings.obj $
   $outdir/tttextfile.obj $
   $outdir/ttdib.obj $
   $outdir/ttdirdlg.obj $

--- a/src/bld/msvc_rel.ninja
+++ b/src/bld/msvc_rel.ninja
@@ -50,6 +50,8 @@ build $outdir/ttlibspace.obj: compile ttlibspace.cpp | $outdir/pch.obj
 
 build $outdir/ttparser.obj: compile ttparser.cpp | $outdir/pch.obj
 
+build $outdir/ttstrings.obj: compile ttstrings.cpp | $outdir/pch.obj
+
 build $outdir/tttextfile.obj: compile tttextfile.cpp | $outdir/pch.obj
 
 build $outdir/ttdib.obj: compile winsrc/ttdib.cpp | $outdir/pch.obj
@@ -85,6 +87,7 @@ build ../lib/ttLib.lib : lib $
   $outdir/ttmultistr.obj $
   $outdir/ttlibspace.obj $
   $outdir/ttparser.obj $
+  $outdir/ttstrings.obj $
   $outdir/tttextfile.obj $
   $outdir/ttdib.obj $
   $outdir/ttdirdlg.obj $

--- a/src/ttstrings.cpp
+++ b/src/ttstrings.cpp
@@ -1,0 +1,127 @@
+/////////////////////////////////////////////////////////////////////////////
+// Name:      ttcstr.cpp
+// Purpose:   Class for handling zero-terminated char strings.
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2020 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include "pch.h"
+
+#include "../include/ttstrings.h"
+
+const char* _tt(int id)
+{
+    assert(_tt_CurLanguage);
+    if (auto result = _tt_CurLanguage->find(id); result != _tt_CurLanguage->end())
+    {
+        return result->second;
+    }
+    return "";
+}
+
+ttlib::cview _ttv(int id)
+{
+    assert(_tt_CurLanguage);
+    if (auto result = _tt_CurLanguage->find(id); result != _tt_CurLanguage->end())
+    {
+        return result->second;
+    }
+    return "";
+}
+
+ttlib::cstr _ttc(int id)
+{
+    assert(_tt_CurLanguage);
+    if (auto result = _tt_CurLanguage->find(id); result != _tt_CurLanguage->end())
+    {
+        return ttlib::cstr(result->second);
+    }
+    return ttlib::cstr();
+}
+
+#if defined(_WIN32)
+
+std::wstring _ttwx(int id)
+{
+    assert(_tt_CurLanguage);
+    if (auto result = _tt_CurLanguage->find(id); result != _tt_CurLanguage->end())
+    {
+        return ttlib::utf8to16(result->second);
+    }
+    return std::wstring();
+}
+
+#endif
+
+const char* _tt(const char* str)
+{
+    if (!_tt_english || !str)
+        return str;
+
+    for (auto iter = _tt_english->begin(); iter != _tt_english->end(); ++iter)
+    {
+        if (ttlib::issameas(iter->second, str))
+        {
+            return _tt(iter->first);
+        }
+    }
+
+    return str;
+}
+
+ttlib::cview _ttv(const char* str)
+{
+    if (!_tt_english || !str)
+        return str;
+
+    for (auto iter = _tt_english->begin(); iter != _tt_english->end(); ++iter)
+    {
+        if (ttlib::issameas(iter->second, str))
+        {
+            return _ttv(iter->first);
+        }
+    }
+
+    return str;
+}
+
+ttlib::cstr _ttc(const char* str)
+{
+    if (!str)
+        return ttlib::cstr();
+    if (!_tt_english)
+        return ttlib::cstr(str);
+
+    for (auto iter = _tt_english->begin(); iter != _tt_english->end(); ++iter)
+    {
+        if (ttlib::issameas(iter->second, str))
+        {
+            return _ttc(iter->first);
+        }
+    }
+
+    return ttlib::cstr(str);
+}
+
+#if defined(_WIN32)
+
+std::wstring _ttwx(const char* str)
+{
+    if (!str)
+        return std::wstring();
+    if (!_tt_english)
+        return ttlib::utf8to16(str);
+
+    for (auto iter = _tt_english->begin(); iter != _tt_english->end(); ++iter)
+    {
+        if (ttlib::issameas(iter->second, str))
+        {
+            return _ttwx(iter->first);
+        }
+    }
+
+    return ttlib::utf8to16(str);
+}
+
+#endif

--- a/src/winsrc/ttdirdlg.cpp
+++ b/src/winsrc/ttdirdlg.cpp
@@ -16,7 +16,6 @@
 
 #include <shlobj.h>
 
-#include "ttTR.h"
 #include "ttdebug.h"  // ttASSERT macros
 #include "ttlibspace.h"
 
@@ -28,7 +27,7 @@ using namespace ttlib;
 
 DirDlg::DirDlg()
 {
-    m_Title = _tt("Select a Folder");
+    m_Title = "Select a Folder";
 }
 
 bool DirDlg::GetFolderName(HWND hwndParent)


### PR DESCRIPTION
### Description:
This PR adds a new mechanism for retrieving localized strings.

Unlike the system implemented in ttTR.h/ttTR.cpp, this system is cross platform and doesn't require any additional tools. It does, however, require a bit more initial work for the caller. As such, documentation is going to be needed for it at some point.

Once the ttTR system is phased out of all KeyWorks projects, it will be removed from ttLib.
