### PR TITLE
Replace our own conversion with std::path.lexically_relative

### DIFF
--- a/src/ttcstr.cpp
+++ b/src/ttcstr.cpp
@@ -607,48 +607,9 @@ cstr& cstr::make_relative(ttlib::cview relative_to)
     if (empty())
         return *this;
 
-    auto to = fs::absolute(fs::u8path(c_str()));
-
-    ttlib::cstr relto;
-    if (relative_to.size())
-    {
-        relto.assign(relative_to);
-    }
-    else
-    {
-        relto.assign(".");
-    }
-    auto from = fs::absolute(fs::u8path(relto.c_str()));
-
-    // At this point, both from and to are absolute paths
-
-    auto iterFrom = from.begin();
-    auto iterTo = to.begin();
-
-    // Loop through both while they are the same to find nearest common directory
-    while (iterFrom != from.end() && iterTo != to.end() && *iterTo == *iterFrom)
-    {
-        ++iterTo;
-        ++iterFrom;
-    }
-
-    // Replace from path segments with '..' (from => nearest common directory)
-    auto finalPath = fs::path {};
-    while (iterFrom != from.end())
-    {
-        finalPath /= "..";
-        ++iterFrom;
-    }
-
-    // Append the remainder of the to path (nearest common directory => to)
-    while (iterTo != to.end())
-    {
-        finalPath /= *iterTo;
-        ++iterTo;
-    }
-
-    assign(finalPath.u8string());
-
+    auto current = fs::absolute(fs::u8path(c_str()));
+    auto rel_to = fs::absolute(fs::u8path(relative_to.c_str()));
+    assign(current.lexically_relative(rel_to).u8string());
     return *this;
 }
 


### PR DESCRIPTION
### Fixes #

### Description:
This PR changes `cstr.make_relative()` to use `fs:path.lexically_relative()` after converting both existing and _relative_to_ paths to absolute. This replaces the previous code where we parsed the paths ourselves, which was returning an incorrect result in some circumstances.

The recent change to `cstr.make_relative()` was to get it to work correctly with paths containing a symbolic link. `fs::relative` resolves all symbolic links, and if a directory is linked to a location on a different drive, `fs::relative` will return an empty string (MSVC compiler, 2020).

