### PR TITLE
Update ttlib::cview class

### DIFF
--- a/include/ttcstr.h
+++ b/include/ttcstr.h
@@ -85,7 +85,7 @@ namespace ttlib
         std::wstring to_utf16() const;
 
         /// Caution: ttlib::cview will be invalid if ttlib::cstr is modified or destroyed.
-        ttlib::cview subview(size_t start = 0) const noexcept
+        ttlib::cview subview(size_t start = 0) const
         {
             if (ttlib::isError(start))
                 start = length();
@@ -220,7 +220,7 @@ namespace ttlib
         cstr& cdecl Format(std::string_view format, ...);
 
         /// Caution: view is only valid until cstr is modified or destroyed!
-        std::string_view subview(size_t start, size_t len) const noexcept;
+        std::string_view subview(size_t start, size_t len) const;
 
         /// Converts all backslashes in the string to forward slashes.
         ///

--- a/include/ttcview.h
+++ b/include/ttcview.h
@@ -26,6 +26,9 @@
 
 #include "ttlibspace.h"  // ttlib namespace functions and declarations
 
+// This can be used to conditionalize code where <ttcview.h> is available or not
+#define _TTLIB_CVIEW_AVAILABLE_
+
 #include <filesystem>
 #include <sstream>
 #include <string_view>

--- a/include/ttcview.h
+++ b/include/ttcview.h
@@ -154,14 +154,13 @@ namespace ttlib
         bool dirExists() const;
 
         /// Returns a view of the characters between chBegin and chEnd. This is typically used
-        /// to view the contents of a quoted string. Returns the position of the ending
-        ///  character in src.
+        /// to view the contents of a quoted string.
         ///
         /// Unless chBegin is a whitespace character, all whitespace characters starting with
         /// offset will be ignored.
-        std::string_view ViewSubString(size_t offset, char chBegin = '"', char chEnd = '"');
+        std::string_view view_substr(size_t offset, char chBegin = '"', char chEnd = '"');
 
-        // All of the following view_() functions will return subview(length()) if the specified character cannot be
+        // All of the following view_() functions will return an empty view if the specified character cannot be
         // found, or the start position is out of range (including start == npos).
 
         cview view_space(size_t start = 0) const { return subview(findspace(start)); }
@@ -174,33 +173,33 @@ namespace ttlib
         size_t gethash() const noexcept;
 
         /////////////////////////////////////////////////////////////////////////////////
-        // Note: all view...() functions start from the beginning of the view. On success
+        // Note: all moveto_() functions start from the beginning of the view. On success
         // they change the view and return true. On failure, the view remains unchanged.
         /////////////////////////////////////////////////////////////////////////////////
 
-        /// Set view to the next whitespace character
-        [[deprecated ("use view_space")]] bool viewspace() noexcept;
+        /// Move start position to the next whitespace character
+        bool moveto_space() noexcept;
 
-        /// Set view to the next non-whitespace character
-        [[deprecated ("use view_nonspace")]] bool viewnonspace() noexcept;
+        /// Move start position to the next non-whitespace character
+        bool moveto_nonspace() noexcept;
 
-        /// Set view to the next word (views the next whitespace, then the next non-whitespace
-        /// after that)
-        [[deprecated ("use view_stepover")]] bool viewnextword() noexcept;
+        /// Move start position to the next word (views the next whitespace, then the next
+        /// non-whitespace after that)
+        bool moveto_nextword() noexcept;
 
-        /// Set view to the next numerical character
-        [[deprecated ("use view_digit")]] bool viewdigit() noexcept;
+        /// Move start position to the next numerical character
+        bool moveto_digit() noexcept;
 
-        /// Set view to the next non-numerical character
-        [[deprecated ("use view_nondigit")]] bool viewnondigit() noexcept;
+        /// Move start position to the next non-numerical character
+        bool moveto_nondigit() noexcept;
 
-        /// Set view to the extension in the current path
-        [[deprecated ("use extension")]] bool viewextension() noexcept;
+        /// Move start position to the extension in the current path
+        bool moveto_extension() noexcept;
 
-        /// Set view to the filename in the current path.
+        /// Move start position to the filename in the current path.
         ///
         /// A filename is any string after the last '/' (or '\' on Windows) in the current
         /// view.
-        [[deprecated ("use filename")]] bool viewfilename() noexcept;
+        bool moveto_filename() noexcept;
     };
 }  // namespace ttlib

--- a/include/ttcview.h
+++ b/include/ttcview.h
@@ -26,8 +26,6 @@
 
 #include "ttlibspace.h"  // ttlib namespace functions and declarations
 
-#define _TTLIB_CVIEW_AVAILABLE_
-
 #include <filesystem>
 #include <sstream>
 #include <string_view>
@@ -53,11 +51,30 @@ namespace ttlib
         /// Can be used to pass the view to a function that expects a C-style string.
         operator const char*() const noexcept { return data(); }
 
-        /// Returns true if the sub-string is identical to the first part of the main string
-        bool issameas(std::string_view str, tt::CASE checkcase = tt::CASE::exact) const;
+#if defined(_WIN32)
+        /// Returns a copy of the string converted to UTF16 on Windows, or a normal copy on other platforms
+        std::wstring wx_str() const { return to_utf16(); };
+#else
+        /// Returns a copy of the string converted to UTF16 on Windows, or a normal copy on other platforms
+        std::string wx_str() const { return std::string(*this); }
+#endif  // _WIN32
 
-        /// Returns true if the sub-string is identical to the first part of the main string
-        bool issameprefix(std::string_view str, tt::CASE checkcase = tt::CASE::exact) const;
+        std::wstring to_utf16() const;
+
+        /// Returns a zero-terminated view. Unlike substr(), you can only specify the starting position.
+        cview subview(size_t start = 0) const
+        {
+            if (start > length())
+                start = length();
+            return cview(c_str() + start, length() - start);
+        }
+
+        /// Calling subview with a length parameter returns a standard string_view instead of
+        /// a zero-terminated cview.
+        std::string_view subview(size_t start, size_t len) const;
+
+        /// Case-insensitive comparison.
+        int comparei(std::string_view str) const;
 
         /// Locates the position of a substring.
         size_t locate(std::string_view str, size_t posStart = 0, tt::CASE check = tt::CASE::exact) const;
@@ -100,6 +117,14 @@ namespace ttlib
         /// Equivalent to findnonspace(findspace(start)).
         size_t stepover(size_t start = 0) const;
 
+        /// Returns true if the sub-string is identical to the first part of the main string
+        bool issameas(std::string_view str, tt::CASE checkcase = tt::CASE::exact) const;
+
+        /// Returns true if the sub-string is identical to the first part of the main string
+        bool issameprefix(std::string_view str, tt::CASE checkcase = tt::CASE::exact) const;
+
+        int atoi() const { return ttlib::atoi(*this); }
+
         // You can't remove a suffix and still have the view zero-terminated
         constexpr void remove_suffix(size_type n) = delete;
 
@@ -125,13 +150,13 @@ namespace ttlib
         /// Returns true if the current string refers to an existing directory.
         bool dirExists() const;
 
-        /// Returns a zero-terminated view. Unlike substr(), you can only specify the starting position.
-        cview subview(size_t start = 0) const
-        {
-            if (start > length())
-                start = length();
-            return cview(c_str() + start, length() - start);
-        }
+        /// Returns a view of the characters between chBegin and chEnd. This is typically used
+        /// to view the contents of a quoted string. Returns the position of the ending
+        ///  character in src.
+        ///
+        /// Unless chBegin is a whitespace character, all whitespace characters starting with
+        /// offset will be ignored.
+        std::string_view ViewSubString(size_t offset, char chBegin = '"', char chEnd = '"');
 
         // All of the following view_() functions will return subview(length()) if the specified character cannot be
         // found, or the start position is out of range (including start == npos).

--- a/include/ttcview.h
+++ b/include/ttcview.h
@@ -126,12 +126,21 @@ namespace ttlib
         bool dirExists() const;
 
         /// Returns a zero-terminated view. Unlike substr(), you can only specify the starting position.
-        cview subview(size_t start = 0) const noexcept
+        cview subview(size_t start = 0) const
         {
-            if (start >= size())
-                return "";
+            if (start > length())
+                start = length();
             return cview(c_str() + start, length() - start);
         }
+
+        // All of the following view_() functions will return subview(length()) if the specified character cannot be
+        // found, or the start position is out of range (including start == npos).
+
+        cview view_space(size_t start = 0) const { return subview(findspace(start)); }
+        cview view_nonspace(size_t start = 0) const { return subview(findnonspace(start)); }
+        cview view_stepover(size_t start = 0) const { return subview(stepover(start)); }
+        cview view_digit(size_t start = 0) const;
+        cview view_nondigit(size_t start = 0) const;
 
         /// Generates hash of current string using djb2 hash algorithm
         size_t gethash() const noexcept;
@@ -142,28 +151,28 @@ namespace ttlib
         /////////////////////////////////////////////////////////////////////////////////
 
         /// Set view to the next whitespace character
-        bool viewspace() noexcept;
+        [[deprecated ("use view_space")]] bool viewspace() noexcept;
 
         /// Set view to the next non-whitespace character
-        bool viewnonspace() noexcept;
+        [[deprecated ("use view_nonspace")]] bool viewnonspace() noexcept;
 
         /// Set view to the next word (views the next whitespace, then the next non-whitespace
         /// after that)
-        bool viewnextword() noexcept;
+        [[deprecated ("use view_stepover")]] bool viewnextword() noexcept;
 
         /// Set view to the next numerical character
-        bool viewdigit() noexcept;
+        [[deprecated ("use view_digit")]] bool viewdigit() noexcept;
 
         /// Set view to the next non-numerical character
-        bool viewnondigit() noexcept;
+        [[deprecated ("use view_nondigit")]] bool viewnondigit() noexcept;
 
         /// Set view to the extension in the current path
-        bool viewextension() noexcept;
+        [[deprecated ("use extension")]] bool viewextension() noexcept;
 
         /// Set view to the filename in the current path.
         ///
         /// A filename is any string after the last '/' (or '\' on Windows) in the current
         /// view.
-        bool viewfilename() noexcept;
+        [[deprecated ("use filename")]] bool viewfilename() noexcept;
     };
 }  // namespace ttlib

--- a/src/ttcstr.cpp
+++ b/src/ttcstr.cpp
@@ -686,7 +686,7 @@ std::wstring cstr::to_utf16() const
     return str16;
 }
 
-std::string_view cstr::subview(size_t start, size_t len) const noexcept
+std::string_view cstr::subview(size_t start, size_t len) const
 {
     if (start >= size())
         return {};

--- a/src/ttcview.cpp
+++ b/src/ttcview.cpp
@@ -123,7 +123,7 @@ size_t cview::locate(std::string_view str, size_t posStart, tt::CASE checkcase) 
     return npos;
 }
 
-bool cview::viewspace() noexcept
+bool cview::moveto_space() noexcept
 {
     if (empty())
         return false;
@@ -142,7 +142,7 @@ bool cview::viewspace() noexcept
     }
 }
 
-bool cview::viewnonspace() noexcept
+bool cview::moveto_nonspace() noexcept
 {
     if (empty())
         return false;
@@ -161,7 +161,7 @@ bool cview::viewnonspace() noexcept
     }
 }
 
-bool cview::viewnextword() noexcept
+bool cview::moveto_nextword() noexcept
 {
     if (empty())
         return false;
@@ -212,7 +212,7 @@ cview cview::view_nondigit(size_t start) const
     return subview(length());
 }
 
-bool cview::viewdigit() noexcept
+bool cview::moveto_digit() noexcept
 {
     if (empty())
         return false;
@@ -231,7 +231,7 @@ bool cview::viewdigit() noexcept
     }
 }
 
-bool cview::viewnondigit() noexcept
+bool cview::moveto_nondigit() noexcept
 {
     if (empty())
         return false;
@@ -250,7 +250,7 @@ bool cview::viewnondigit() noexcept
     }
 }
 
-bool cview::viewextension() noexcept
+bool cview::moveto_extension() noexcept
 {
     if (empty())
         return false;
@@ -267,7 +267,7 @@ bool cview::viewextension() noexcept
     return true;
 }
 
-bool cview::viewfilename() noexcept
+bool cview::moveto_filename() noexcept
 {
     if (empty())
         return false;
@@ -454,7 +454,7 @@ std::string_view cview::subview(size_t start, size_t len) const
  * @param chBegin -- character that prefixes the string
  * @param chEnd -- character that terminates the string.
  */
-std::string_view cview::ViewSubString(size_t offset, char chBegin, char chEnd)
+std::string_view cview::view_substr(size_t offset, char chBegin, char chEnd)
 {
     if (empty() || offset >= size())
     {

--- a/src/ttcview.cpp
+++ b/src/ttcview.cpp
@@ -190,6 +190,28 @@ bool cview::viewnextword() noexcept
     }
 }
 
+cview cview::view_digit(size_t start) const
+{
+    for (; start < length(); ++start)
+    {
+        if (ttlib::isdigit(at(start)))
+            return subview(start);
+    }
+
+    return subview(length());
+}
+
+cview cview::view_nondigit(size_t start) const
+{
+    for (; start < length(); ++start)
+    {
+        if (!ttlib::isdigit(at(start)))
+            return subview(start);
+    }
+
+    return subview(length());
+}
+
 bool cview::viewdigit() noexcept
 {
     if (empty())


### PR DESCRIPTION
### Fixes #

### Description:
The purpose of this PR is to make **cview** and **cstr** have identical functionality for any function that doesn't modify the contents.

This adds `view_()` functions that return a **cview** instead of a bool which allows chaining functions as well as matching what `ttlib::cstr` does. This also adds some additional functions that work identically to the same function in `ttlib::cstr`.

Note that the new view functions use snake_case, and the old view functions that return a bool have been changed to `moveto_()` function names. A future PR will be adding snake_case functions, so this anticipates that change by adding the new view functions using the soon-to-be standard snake_case functions.

The only reason we're allowing a function name change is because github currently lists only two unique clones which would be our two contributors. Once there's a third unique clone, then we can no longer change functions to avoid the risk of breaking a non-KeyWorks project.

