### PR TITLE
Switch to snake_case function names

### DIFF
--- a/include/ttcstr.h
+++ b/include/ttcstr.h
@@ -52,11 +52,12 @@ namespace ttlib
 
         cstr(const std::filesystem::directory_entry& dir) : bs(dir.path().string(), dir.path().string().size()) {}
 
-        cstr& assignUTF16(std::wstring_view str)
+        cstr& from_utf16(std::wstring_view str)
         {
             *this = utf16to8(str);
             return *this;
         }
+        std::wstring to_utf16() const;
 
         /// If you pass wxWidgets::wx_str() to this function it will convert from UTF16 to
         /// UTF8 on Windows, or copy it on other platforms
@@ -82,12 +83,10 @@ namespace ttlib
         std::string wx_str() const { return substr(); }
 #endif  // _WIN32
 
-        std::wstring to_utf16() const;
-
         /// Caution: ttlib::cview will be invalid if ttlib::cstr is modified or destroyed.
         ttlib::cview subview(size_t start = 0) const
         {
-            if (ttlib::isError(start))
+            if (ttlib::is_error(start))
                 start = length();
             assert(start <= length());
             return ttlib::cview(c_str() + start, length() - start);
@@ -117,44 +116,44 @@ namespace ttlib
         /// Find any one of the characters in a set. Returns offset if found, npos if not.
         ///
         /// This is equivalent to calling std::strpbrk but returns an offset instead of a pointer.
-        size_t findoneof(const char* pszSet) const;
+        size_t find_oneof(const char* pszSet) const;
 
         /// Returns offset to the next whitespace character starting with pos. Returns npos if
         /// there are no more whitespaces.
         ///
         /// A whitespace character is a space, tab, eol or form feed character.
-        size_t findspace(size_t start = 0) const;
-        ttlib::cview viewspace(size_t start = 0) const { return subview(findspace(start)); }
+        size_t find_space(size_t start = 0) const;
+        ttlib::cview view_space(size_t start = 0) const { return subview(find_space(start)); }
 
         /// Returns offset to the next non-whitespace character starting with pos. Returns npos
         /// if there are no more non-whitespace characters.
         ///
         /// A whitespace character is a space, tab, eol or form feed character.
-        size_t findnonspace(size_t start = 0) const;
-        ttlib::cview viewnonspace(size_t start = 0) const { return subview(findnonspace(start)); }
+        size_t find_nonspace(size_t start = 0) const;
+        ttlib::cview view_nonspace(size_t start = 0) const { return subview(find_nonspace(start)); }
 
         /// Returns an offset to the next word -- i.e., find the first non-whitedspace character
         /// after the next whitespace character.
         ///
-        /// Equivalent to findnonspace(findspace(start)).
+        /// Equivalent to find_nonspace(find_space(start)).
         size_t stepover(size_t start = 0) const;
-        ttlib::cview viewstepover(size_t start = 0) const { return subview(stepover(start)); }
+        ttlib::cview view_stepover(size_t start = 0) const { return subview(stepover(start)); }
 
         /// Returns true if the sub-string is identical to the first part of the main string
-        bool issameas(std::string_view str, tt::CASE checkcase = tt::CASE::exact) const;
+        bool is_sameas(std::string_view str, tt::CASE checkcase = tt::CASE::exact) const;
 
         /// Returns true if the sub-string is identical to the first part of the main string
-        bool issameprefix(std::string_view str, tt::CASE checkcase = tt::CASE::exact) const;
+        bool is_sameprefix(std::string_view str, tt::CASE checkcase = tt::CASE::exact) const;
 
         int atoi() const { return ttlib::atoi(*this); }
 
         /// If character is found, line is truncated from the character on, and then
         /// any trailing space is removed;
-        void eraseFrom(char ch);
+        void erase_from(char ch);
 
         /// If string is found, line is truncated from the string on, and then
         /// any trailing space is removed;
-        void eraseFrom(std::string_view sub);
+        void erase_from(std::string_view sub);
 
         /// Removes whitespace: ' ', \t, \r, \\n, \f
         ///
@@ -167,7 +166,7 @@ namespace ttlib
         ///
         /// Unless chBegin is a whitespace character, all whitespace characters starting with
         /// offset will be ignored.
-        std::string_view ViewSubString(size_t offset, char chBegin = '"', char chEnd = '"');
+        std::string_view view_substr(size_t offset, char chBegin = '"', char chEnd = '"');
 
         /// Assigns the string between chBegin and chEnd. This is typically used to copy the
         /// contents of a quoted string. Returns the position of the ending character in src.
@@ -185,18 +184,18 @@ namespace ttlib
         size_t ExtractSubString(std::string_view src, size_t offset = 0);
 
         /// Replace first (or all) occurrences of substring with another one
-        size_t Replace(std::string_view oldtext, std::string_view newtext, bool replaceAll = tt::REPLACE::once,
+        size_t Replace(std::string_view oldtext, std::string_view newtext, bool replace_all = tt::REPLACE::once,
                        tt::CASE checkcase = tt::CASE::exact);
 
         /// Replace everything from pos to the end of the current string with str
-        cstr& replaceAll(size_t pos, std::string_view str)
+        cstr& replace_all(size_t pos, std::string_view str)
         {
             replace(pos, length() - pos, str);
             return *this;
         }
 
         /// Generates hash of current string using djb2 hash algorithm
-        size_t gethash() const noexcept;
+        size_t get_hash() const noexcept;
 
         /// Convert the entire string to lower case. Assumes the string is UTF8.
         cstr& MakeLower();
@@ -235,10 +234,10 @@ namespace ttlib
         }
 
         /// Returns true if current filename contains the specified case-insensitive extension.
-        bool hasExtension(std::string_view ext) const { return ttlib::issameas(extension(), ext, tt::CASE::either); }
+        bool has_extension(std::string_view ext) const { return ttlib::is_sameas(extension(), ext, tt::CASE::either); }
 
         /// Returns true if current filename contains the specified case-insensitive file name.
-        bool hasFilename(std::string_view name) const { return ttlib::issameas(filename(), name, tt::CASE::either); }
+        bool has_filename(std::string_view name) const { return ttlib::is_sameas(filename(), name, tt::CASE::either); }
 
         /// Returns a view to the current extension. View is empty if there is no extension.
         ///
@@ -288,10 +287,10 @@ namespace ttlib
         cstr& assignCwd();
 
         /// Returns true if the current string refers to an existing file.
-        bool fileExists() const;
+        bool file_exists() const;
 
         /// Returns true if the current string refers to an existing directory.
-        bool dirExists() const;
+        bool dir_exists() const;
 
         cstr& operator<<(std::string_view str)
         {

--- a/include/ttcvector.h
+++ b/include/ttcvector.h
@@ -38,7 +38,7 @@ namespace ttlib
         /// Only adds the string if it doesn't already exist.
         ttlib::cstr& append(T str, tt::CASE checkcase = tt::CASE::exact)
         {
-            if (auto index = find(0, str, checkcase); !ttlib::isError(index))
+            if (auto index = find(0, str, checkcase); !ttlib::is_error(index))
             {
                 return at(index);
             }
@@ -56,7 +56,7 @@ namespace ttlib
 #endif  // _WIN32
         }
 
-        bool hasFilename(std::string_view filename) const
+        bool has_filename(std::string_view filename) const
         {
 #if defined(_WIN32)
             return (find(0, filename, tt::CASE::either) != tt::npos);

--- a/include/ttcview.h
+++ b/include/ttcview.h
@@ -100,31 +100,31 @@ namespace ttlib
         /// Find any one of the characters in a set. Returns offset if found, npos if not.
         ///
         /// This is equivalent to calling std::strpbrk but returns an offset instead of a pointer.
-        size_t findoneof(const std::string& set) const;
+        size_t find_oneof(const std::string& set) const;
 
         /// Returns offset to the next whitespace character starting with pos. Returns npos if
         /// there are no more whitespaces.
         ///
         /// A whitespace character is a space, tab, eol or form feed character.
-        size_t findspace(size_t start = 0) const;
+        size_t find_space(size_t start = 0) const;
 
         /// Returns offset to the next non-whitespace character starting with pos. Returns npos
         /// if there are no more non-whitespace characters.
         ///
         /// A whitespace character is a space, tab, eol or form feed character.
-        size_t findnonspace(size_t start = 0) const;
+        size_t find_nonspace(size_t start = 0) const;
 
         /// Returns an offset to the next word -- i.e., find the first non-whitedspace character
         /// after the next whitespace character.
         ///
-        /// Equivalent to findnonspace(findspace(start)).
+        /// Equivalent to find_nonspace(find_space(start)).
         size_t stepover(size_t start = 0) const;
 
         /// Returns true if the sub-string is identical to the first part of the main string
-        bool issameas(std::string_view str, tt::CASE checkcase = tt::CASE::exact) const;
+        bool is_sameas(std::string_view str, tt::CASE checkcase = tt::CASE::exact) const;
 
         /// Returns true if the sub-string is identical to the first part of the main string
-        bool issameprefix(std::string_view str, tt::CASE checkcase = tt::CASE::exact) const;
+        bool is_sameprefix(std::string_view str, tt::CASE checkcase = tt::CASE::exact) const;
 
         int atoi() const { return ttlib::atoi(*this); }
 
@@ -132,10 +132,10 @@ namespace ttlib
         constexpr void remove_suffix(size_type n) = delete;
 
         /// Returns true if current filename contains the specified case-insensitive extension.
-        bool hasExtension(std::string_view ext) const { return ttlib::issameas(extension(), ext, tt::CASE::either); }
+        bool has_extension(std::string_view ext) const { return ttlib::is_sameas(extension(), ext, tt::CASE::either); }
 
         /// Returns true if current filename contains the specified case-insensitive file name.
-        bool hasFilename(std::string_view name) const { return ttlib::issameas(filename(), name, tt::CASE::either); }
+        bool has_filename(std::string_view name) const { return ttlib::is_sameas(filename(), name, tt::CASE::either); }
 
         /// Returns a view to the current extension. View is empty if there is no extension.
         ///
@@ -148,10 +148,10 @@ namespace ttlib
         ttlib::cview filename() const noexcept;
 
         /// Returns true if the current string refers to an existing file.
-        bool fileExists() const;
+        bool file_exists() const;
 
         /// Returns true if the current string refers to an existing directory.
-        bool dirExists() const;
+        bool dir_exists() const;
 
         /// Returns a view of the characters between chBegin and chEnd. This is typically used
         /// to view the contents of a quoted string.
@@ -163,14 +163,14 @@ namespace ttlib
         // All of the following view_() functions will return an empty view if the specified character cannot be
         // found, or the start position is out of range (including start == npos).
 
-        cview view_space(size_t start = 0) const { return subview(findspace(start)); }
-        cview view_nonspace(size_t start = 0) const { return subview(findnonspace(start)); }
+        cview view_space(size_t start = 0) const { return subview(find_space(start)); }
+        cview view_nonspace(size_t start = 0) const { return subview(find_nonspace(start)); }
         cview view_stepover(size_t start = 0) const { return subview(stepover(start)); }
         cview view_digit(size_t start = 0) const;
         cview view_nondigit(size_t start = 0) const;
 
         /// Generates hash of current string using djb2 hash algorithm
-        size_t gethash() const noexcept;
+        size_t get_hash() const noexcept;
 
         /////////////////////////////////////////////////////////////////////////////////
         // Note: all moveto_() functions start from the beginning of the view. On success

--- a/include/ttlibspace.h
+++ b/include/ttlibspace.h
@@ -97,53 +97,53 @@ namespace ttlib
     extern const std::string emptystring;
 
     /// Only valid for ANSI characters
-    constexpr inline bool isalpha(char ch) noexcept { return ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')); }
+    constexpr inline bool is_alpha(char ch) noexcept { return ((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')); }
 
-    constexpr inline bool isdigit(char ch) noexcept { return ((ch >= '0' && ch <= '9') || ch == '-'); }
+    constexpr inline bool is_digit(char ch) noexcept { return ((ch >= '0' && ch <= '9') || ch == '-'); }
 
     /// Is ch the start of a utf8 sequence?
-    constexpr inline bool isutf8(char ch) noexcept { return ((ch & 0xC0) != 0x80); }
+    constexpr inline bool is_utf8(char ch) noexcept { return ((ch & 0xC0) != 0x80); }
 
     /// Returns true if character is a space, tab, eol or form feed character.
-    constexpr inline bool iswhitespace(char ch) noexcept { return (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '\f'); }
+    constexpr inline bool is_whitespace(char ch) noexcept { return (ch == ' ' || ch == '\t' || ch == '\n' || ch == '\r' || ch == '\f'); }
 
     /// Returns true if character is a period, comma, semi-colon, colon, question or exclamation
-    constexpr inline bool ispunctuation(char ch) noexcept
+    constexpr inline bool is_punctuation(char ch) noexcept
     {
         return (ch == '.' || ch == ',' || ch == ';' || ch == ':' || ch == '?' || ch == '!');
     }
 
     template<typename T>
-    /// Compares result against -1
-    constexpr bool isError(T result)
+    /// Compares result against -1 -- use with returns from find, contains, locate, etc.
+    constexpr bool is_error(T result)
     {
         return (static_cast<ptrdiff_t>(result)) == -1;
     }
 
     template<typename T>
     /// Compares result against -1 -- use with returns from find, contains, locate, etc.
-    constexpr bool isFound(T result)
+    constexpr bool is_found(T result)
     {
         return (static_cast<ptrdiff_t>(result)) != -1;
     }
 
     /// Returns true if strings are identical
-    bool issameas(std::string_view str1, std::string_view str2, tt::CASE checkcase = tt::CASE::exact);
+    bool is_sameas(std::string_view str1, std::string_view str2, tt::CASE checkcase = tt::CASE::exact);
 
     /// Returns true if the sub-string is identical to the first part of the main string
-    bool issameprefix(std::string_view strMain, std::string_view strSub, tt::CASE checkcase = tt::CASE::exact);
+    bool is_sameprefix(std::string_view strMain, std::string_view strSub, tt::CASE checkcase = tt::CASE::exact);
 
     /// Return a view to the portion of the string beginning with the sub string.
     ///
     /// Return view is empty if substring is not found.
-    std::string_view findstr(std::string_view main, std::string_view sub, tt::CASE checkcase = tt::CASE::exact);
+    std::string_view find_str(std::string_view main, std::string_view sub, tt::CASE checkcase = tt::CASE::exact);
 
     /// Returns the position of sub within main, or npos if not found.
     size_t findstr_pos(std::string_view main, std::string_view sub, tt::CASE checkcase = tt::CASE::exact);
 
     /// Returns true if the sub string exists withing the main string.
     ///
-    /// Same as findstr but with a boolean return instead of a string_view.
+    /// Same as find_str but with a boolean return instead of a string_view.
     bool contains(std::string_view main, std::string_view sub, tt::CASE checkcase = tt::CASE::exact);
 
     template<class iterT>
@@ -159,42 +159,42 @@ namespace ttlib
     }
 
     /// Returns a pointer to the next character in a UTF8 string.
-    const char* nextut8fchar(const char* psz) noexcept;
+    const char* next_utf8_char(const char* psz) noexcept;
 
     /// Returns view to the next whitespace character. View is empty if there are no more
     /// whitespaces.
-    std::string_view findspace(std::string_view str) noexcept;
+    std::string_view find_space(std::string_view str) noexcept;
 
     /// Returns position of next whitespace character or npos if not found.
-    size_t findspace_pos(std::string_view str);
+    size_t find_space_pos(std::string_view str);
 
     /// Returns view to the next non-whitespace character. View is empty if there are no
     /// non-whitespace characters.
-    std::string_view findnonspace(std::string_view str) noexcept;
+    std::string_view find_nonspace(std::string_view str) noexcept;
 
     /// Returns position of next non-whitespace character or npos if not found.
-    size_t findnonspace_pos(std::string_view str) noexcept;
+    size_t find_nonspace_pos(std::string_view str) noexcept;
 
-    /// Equivalent to findnonspace(findspace(str)).
+    /// Equivalent to find_nonspace(find_space(str)).
     std::string_view stepover(std::string_view str) noexcept;
 
-    /// Equivalent to findnonspace(findspace(str)) returning the position or npos.
+    /// Equivalent to find_nonspace(find_space(str)) returning the position or npos.
     size_t stepover_pos(std::string_view str) noexcept;
 
     /// Returns a zero-terminated view of the first whitespace character. View is empty if
     /// there is no whitespace character.
-    cview viewSpace(const std::string& str, size_t startpos = 0) noexcept;
+    cview view_space(const std::string& str, size_t startpos = 0) noexcept;
 
     /// Returns a zero-terminated view of the first non-whitespace character. View is empty
     /// if there is no non-whitespace character.
-    cview viewNonspace(const std::string& str, size_t startpos = 0) noexcept;
+    cview view_nonspace(const std::string& str, size_t startpos = 0) noexcept;
 
     /// Locates the next whitespace character, and returns a zero-terminated view to the
     /// first non-whitespace character after that whitespace character.
-    cview viewStepover(const std::string& str, size_t startpos = 0) noexcept;
+    cview view_stepover(const std::string& str, size_t startpos = 0) noexcept;
 
     /// Generates hash of string using djb2 hash algorithm
-    size_t gethash(std::string_view str) noexcept;
+    size_t get_hash(std::string_view str) noexcept;
 
     /// Converts a string into an integer.
     ///
@@ -215,12 +215,12 @@ namespace ttlib
     ttlib::cstr itoa(size_t val, bool format = false);
 
     /// Return a view to a filename's extension. View is empty if there is no extension.
-    std::string_view findext(std::string_view str);
+    std::string_view find_extension(std::string_view str);
 
     /// Determines whether the character at pos is part of a filename. This will
     /// differentiate between '.' being used as part of a path (. for current directory, or ..
     /// for relative directory) versus being the leading character in a file.
-    bool isvalidfilechar(std::string_view str, size_t pos);
+    bool is_valid_filechar(std::string_view str, size_t pos);
 
     /// Converts all backslashes in a filename to forward slashes.
     ///
@@ -230,7 +230,7 @@ namespace ttlib
 
     /// Performs a check to see if a directory entry is a filename and contains the
     /// specified extension.
-    bool hasextension(std::filesystem::directory_entry name, std::string_view extension, tt::CASE checkcase = tt::CASE::exact);
+    bool has_extension(std::filesystem::directory_entry name, std::string_view extension, tt::CASE checkcase = tt::CASE::exact);
 
     /// Confirms newdir exists and is a directory and then changes to that directory.
     ///
@@ -238,8 +238,8 @@ namespace ttlib
     /// if the directory is valid but could not be changed to.
     bool ChangeDir(std::string_view newdir);
 
-    bool dirExists(std::string_view dir);
-    bool fileExists(std::string_view filename);
+    bool dir_exists(std::string_view dir);
+    bool file_exists(std::string_view filename);
 
     void utf8to16(std::string_view str, std::wstring& dest);
     void utf16to8(std::wstring_view str, std::string& dest);

--- a/include/tttextfile.h
+++ b/include/tttextfile.h
@@ -25,7 +25,7 @@
 ///         ttlib::textfile file;
 ///         file.ReadFile(original.GetContainer());
 ///             ... // possible modifications.
-///         if (!file.issameas(original))
+///         if (!file.is_sameas(original))
 ///             file.WriteFile("your filename");
 ///      }
 ///
@@ -90,8 +90,8 @@ namespace ttlib
         size_t ReplaceInLine(std::string_view orgStr, std::string_view newStr, size_t startline = 0,
                              tt::CASE checkcase = tt::CASE::exact);
 
-        bool issameas(ttlib::textfile other, tt::CASE checkcase = tt::CASE::exact) const;
-        bool issameas(ttlib::viewfile other, tt::CASE checkcase = tt::CASE::exact) const;
+        bool is_sameas(ttlib::textfile other, tt::CASE checkcase = tt::CASE::exact) const;
+        bool is_sameas(ttlib::viewfile other, tt::CASE checkcase = tt::CASE::exact) const;
 
         /// Use addEmptyLine() if you need to modify the line after adding it to the end.
         ///
@@ -175,8 +175,8 @@ namespace ttlib
         size_t FindLineContaining(std::string_view str, size_t startline = 0,
                                   tt::CASE checkcase = tt::CASE::exact) const;
 
-        bool issameas(ttlib::textfile other, tt::CASE checkcase = tt::CASE::exact) const;
-        bool issameas(ttlib::viewfile other, tt::CASE checkcase = tt::CASE::exact) const;
+        bool is_sameas(ttlib::textfile other, tt::CASE checkcase = tt::CASE::exact) const;
+        bool is_sameas(ttlib::viewfile other, tt::CASE checkcase = tt::CASE::exact) const;
 
     protected:
         // Converts lines into a vector of std::string_view members. Lines can end with \n, \r, or \r\n.

--- a/include/ttwinff.h
+++ b/include/ttwinff.h
@@ -65,7 +65,7 @@ namespace ttlib
             else if (cFileName[0] == L'.' && cFileName[1] == L'.' && !cFileName[2])
                 next();
             else
-                m_filename.assignUTF16(cFileName);
+                m_filename.from_utf16(cFileName);
         }
         ~winff()
         {
@@ -85,7 +85,7 @@ namespace ttlib
                     return next();
                 else if (cFileName[0] == L'.' && cFileName[1] == L'.' && !cFileName[2])
                     return next();
-                m_filename.assignUTF16(cFileName);
+                m_filename.from_utf16(cFileName);
                 return true;
             }
             else
@@ -105,7 +105,7 @@ namespace ttlib
             std::wstring str16;
             ttlib::utf8to16(filepattern, str16);
             m_hfind = FindFirstFileExW(str16.c_str(), FindExInfoBasic, this, FindExSearchNameMatch, nullptr, FIND_FIRST_EX_LARGE_FETCH);
-            m_filename.assignUTF16(cFileName);
+            m_filename.from_utf16(cFileName);
 
             // Use same rule as std::filesystem directory_iterator and skip . and ..
             if (cFileName[0] == L'.' && !cFileName[1])
@@ -113,7 +113,7 @@ namespace ttlib
             else if (cFileName[0] == L'.' && cFileName[1] == L'.' && !cFileName[2])
                 next();
             else
-                m_filename.assignUTF16(cFileName);
+                m_filename.from_utf16(cFileName);
             return isvalid();
         }
 
@@ -127,8 +127,8 @@ namespace ttlib
         char operator[](int pos) { return m_filename.at(pos); }
         char operator[](size_t pos) { return m_filename.at(pos); }
 
-        bool operator==(std::string_view name) { return m_filename.issameas(name); }
-        bool operator!=(std::string_view name) { return !m_filename.issameas(name); }
+        bool operator==(std::string_view name) { return m_filename.is_sameas(name); }
+        bool operator!=(std::string_view name) { return !m_filename.is_sameas(name); }
 
         // Caution: this is NOT a copy! It returns a pointer to the internal cstr buffer. Any
         // changes you make will be overwritten by a call to next() or newpattern().

--- a/src/ttcstr.cpp
+++ b/src/ttcstr.cpp
@@ -25,7 +25,7 @@ using namespace tt;
 
 namespace fs = std::filesystem;
 
-bool cstr::issameas(std::string_view str, CASE checkcase) const
+bool cstr::is_sameas(std::string_view str, CASE checkcase) const
 {
     if (size() != str.size())
         return false;
@@ -34,10 +34,10 @@ bool cstr::issameas(std::string_view str, CASE checkcase) const
         return str.empty();
 
     // if both strings have the same length and are non-empty, then we can compare as a prefix.
-    return issameprefix(str, checkcase);
+    return is_sameprefix(str, checkcase);
 }
 
-bool cstr::issameprefix(std::string_view str, CASE checkcase) const
+bool cstr::is_sameprefix(std::string_view str, CASE checkcase) const
 {
     if (str.empty())
         return empty();
@@ -120,13 +120,13 @@ cstr& cstr::trim(tt::TRIM where)
     {
         // Assume that most strings won't start with whitespace, so return as quickly as possible if that is the
         // case.
-        if (!ttlib::iswhitespace(front()))
+        if (!ttlib::is_whitespace(front()))
             return *this;
 
         size_t pos;
         for (pos = 1; pos < length(); ++pos)
         {
-            if (!ttlib::iswhitespace(c_str()[pos]))
+            if (!ttlib::is_whitespace(c_str()[pos]))
                 break;
         }
         replace(0, length(), substr(pos, length() - pos));
@@ -138,7 +138,7 @@ cstr& cstr::trim(tt::TRIM where)
  * @param chBegin -- character that prefixes the string
  * @param chEnd -- character that terminates the string.
  */
-std::string_view cstr::ViewSubString(size_t offset, char chBegin, char chEnd)
+std::string_view cstr::view_substr(size_t offset, char chBegin, char chEnd)
 {
     if (empty() || offset >= size())
     {
@@ -146,9 +146,9 @@ std::string_view cstr::ViewSubString(size_t offset, char chBegin, char chEnd)
     }
 
     // step over any leading whitespace unless chBegin is a whitespace character
-    if (!ttlib::iswhitespace(chBegin))
+    if (!ttlib::is_whitespace(chBegin))
     {
-        while (ttlib::iswhitespace(at(offset)))
+        while (ttlib::is_whitespace(at(offset)))
             ++offset;
     }
 
@@ -197,9 +197,9 @@ size_t cstr::AssignSubString(std::string_view src, char chBegin, char chEnd)
 
     size_t pos = 0;
     // step over any leading whitespace unless chBegin is a whitespace character
-    if (!ttlib::iswhitespace(chBegin))
+    if (!ttlib::is_whitespace(chBegin))
     {
-        while (ttlib::iswhitespace(src[pos]))
+        while (ttlib::is_whitespace(src[pos]))
             ++pos;
     }
 
@@ -249,7 +249,7 @@ size_t cstr::ExtractSubString(std::string_view src, size_t start)
 
     // start by finding the first non-whitespace character
     size_t pos = start;
-    while (pos < src.length() && ttlib::iswhitespace(src[pos]))
+    while (pos < src.length() && ttlib::is_whitespace(src[pos]))
     {
         ++pos;
     }
@@ -300,17 +300,17 @@ size_t cstr::ExtractSubString(std::string_view src, size_t start)
 /**
  * @param oldtext -- the text to search for
  * @param newtext -- the text to replace it with
- * @param replaceAll -- replace all occurrences or just the first one
+ * @param replace_all -- replace all occurrences or just the first one
  * @param CaseSensitive -- indicates whether or not to use a case-insensitive search
  * @return Number of replacements made
  */
-size_t cstr::Replace(std::string_view oldtext, std::string_view newtext, bool replaceAll, tt::CASE checkcase)
+size_t cstr::Replace(std::string_view oldtext, std::string_view newtext, bool replace_all, tt::CASE checkcase)
 {
     if (oldtext.empty())
         return false;
 
     size_t replacements = 0;
-    if (auto pos = locate(oldtext, 0, checkcase); ttlib::isFound(pos))
+    if (auto pos = locate(oldtext, 0, checkcase); ttlib::is_found(pos))
     {
         do
         {
@@ -318,10 +318,10 @@ size_t cstr::Replace(std::string_view oldtext, std::string_view newtext, bool re
             insert(pos, newtext);
             ++replacements;
             pos += newtext.length();
-            if (pos >= size() || !replaceAll)
+            if (pos >= size() || !replace_all)
                 break;
             pos = locate(oldtext, pos, checkcase);
-        } while (ttlib::isFound(pos));
+        } while (ttlib::is_found(pos));
     }
 
     return replacements;
@@ -379,7 +379,7 @@ size_t cstr::locate(std::string_view str, size_t posStart, CASE checkcase) const
     return npos;
 }
 
-size_t cstr::gethash() const noexcept
+size_t cstr::get_hash() const noexcept
 {
     if (empty())
         return 0;
@@ -441,7 +441,7 @@ cstr& cstr::replace_extension(std::string_view newExtension)
         return *this;
     }
 
-    if (auto pos = find_last_of('.'); ttlib::isFound(pos))
+    if (auto pos = find_last_of('.'); ttlib::is_found(pos))
     {
         // If the string only contains . or .. then it is a folder
         if (pos == 0 || (pos == 1 && at(0) != '.'))
@@ -477,7 +477,7 @@ ttlib::cview cstr::extension() const noexcept
         return "";
 
     auto pos = find_last_of('.');
-    if (!ttlib::isFound(pos))
+    if (!ttlib::is_found(pos))
         return "";
 
     // . by itself is a folder
@@ -623,7 +623,7 @@ cstr& cstr::make_absolute()
     return *this;
 }
 
-bool cstr::fileExists() const
+bool cstr::file_exists() const
 {
     if (empty())
         return false;
@@ -631,7 +631,7 @@ bool cstr::fileExists() const
     return (file.exists() && !file.is_directory());
 }
 
-bool cstr::dirExists() const
+bool cstr::dir_exists() const
 {
     if (empty())
         return false;
@@ -639,7 +639,7 @@ bool cstr::dirExists() const
     return (file.exists() && file.is_directory());
 }
 
-size_t cstr::findoneof(const char* pszSet) const
+size_t cstr::find_oneof(const char* pszSet) const
 {
     if (!pszSet || !*pszSet)
         return npos;
@@ -649,7 +649,7 @@ size_t cstr::findoneof(const char* pszSet) const
     return (static_cast<size_t>(pszFound - c_str()));
 }
 
-size_t cstr::findspace(size_t start) const
+size_t cstr::find_space(size_t start) const
 {
     if (start >= length())
         return npos;
@@ -659,7 +659,7 @@ size_t cstr::findspace(size_t start) const
     return (static_cast<size_t>(pszFound - c_str()));
 }
 
-size_t cstr::findnonspace(size_t start) const
+size_t cstr::find_nonspace(size_t start) const
 {
     for (; start < length(); ++start)
     {
@@ -671,10 +671,10 @@ size_t cstr::findnonspace(size_t start) const
 
 size_t cstr::stepover(size_t start) const
 {
-    auto pos = findspace(start);
+    auto pos = find_space(start);
     if (pos != npos)
     {
-        pos = findnonspace(pos);
+        pos = find_nonspace(pos);
     }
     return pos;
 }
@@ -709,7 +709,7 @@ bool cstr::assignEnvVar(ttlib::cview env_var)
     return true;
 }
 
-void cstr::eraseFrom(char ch)
+void cstr::erase_from(char ch)
 {
     auto pos = find(ch);
     if (pos != tt::npos)
@@ -719,7 +719,7 @@ void cstr::eraseFrom(char ch)
     }
 }
 
-void cstr::eraseFrom(std::string_view sub)
+void cstr::erase_from(std::string_view sub)
 {
     auto pos = find(sub);
     if (pos != tt::npos)
@@ -837,14 +837,14 @@ cstr& cdecl cstr::Format(std::string_view format, ...)
                 ++pos;
             }
 
-            if (ttlib::isdigit(format[pos]))
+            if (ttlib::is_digit(format[pos]))
             {
                 auto fieldWidth = ttlib::atoi(format.substr(pos));
                 buffer << std::setw(fieldWidth);
                 do
                 {
                     ++pos;
-                } while (pos < format.length() && ttlib::isdigit(format[pos]));
+                } while (pos < format.length() && ttlib::is_digit(format[pos]));
             }
 
             // For both %lc and %ls we assume a UTF16 string and convert it to UTF8.

--- a/src/ttcvector.cpp
+++ b/src/ttcvector.cpp
@@ -18,7 +18,7 @@ size_t cstrVector::find(size_t start, std::string_view str, CASE checkcase) cons
 {
     for (; start < size(); ++start)
     {
-        if (ttlib::issameas(at(start), str, checkcase))
+        if (ttlib::is_sameas(at(start), str, checkcase))
             return start;
     }
     return tt::npos;
@@ -30,7 +30,7 @@ size_t cstrVector::findprefix(size_t start, std::string_view str, CASE checkcase
     {
         for (; start < size(); ++start)
         {
-            if (ttlib::issameprefix(at(start), str, checkcase))
+            if (ttlib::is_sameprefix(at(start), str, checkcase))
                 return start;
         }
     }
@@ -38,7 +38,7 @@ size_t cstrVector::findprefix(size_t start, std::string_view str, CASE checkcase
     {
         for (; start < size(); ++start)
         {
-            if (ttlib::issameprefix(at(start), str, checkcase))
+            if (ttlib::is_sameprefix(at(start), str, checkcase))
                 return start;
         }
     }

--- a/src/ttcview.cpp
+++ b/src/ttcview.cpp
@@ -16,7 +16,7 @@
 
 using namespace ttlib;
 
-bool cview::issameas(std::string_view str, tt::CASE checkcase) const
+bool cview::is_sameas(std::string_view str, tt::CASE checkcase) const
 {
     if (size() != str.size())
         return false;
@@ -25,10 +25,10 @@ bool cview::issameas(std::string_view str, tt::CASE checkcase) const
         return str.empty();
 
     // if both strings have the same length, then we can compare as a prefix.
-    return issameprefix(str, checkcase);
+    return is_sameprefix(str, checkcase);
 }
 
-bool cview::issameprefix(std::string_view str, tt::CASE checkcase) const
+bool cview::is_sameprefix(std::string_view str, tt::CASE checkcase) const
 {
     if (str.empty())
         return empty();
@@ -130,7 +130,7 @@ bool cview::moveto_space() noexcept
     size_t pos;
     for (pos = 0; pos < length(); ++pos)
     {
-        if (ttlib::iswhitespace(at(pos)))
+        if (ttlib::is_whitespace(at(pos)))
             break;
     }
     if (pos >= length())
@@ -149,7 +149,7 @@ bool cview::moveto_nonspace() noexcept
     size_t pos;
     for (pos = 0; pos < length(); ++pos)
     {
-        if (!ttlib::iswhitespace(at(pos)))
+        if (!ttlib::is_whitespace(at(pos)))
             break;
     }
     if (pos >= length())
@@ -168,7 +168,7 @@ bool cview::moveto_nextword() noexcept
     size_t pos;
     for (pos = 0; pos < length(); ++pos)
     {
-        if (ttlib::iswhitespace(at(pos)))
+        if (ttlib::is_whitespace(at(pos)))
             break;
     }
     if (pos >= length())
@@ -179,7 +179,7 @@ bool cview::moveto_nextword() noexcept
     {
         for (++pos; pos < length(); ++pos)
         {
-            if (!ttlib::iswhitespace(at(pos)))
+            if (!ttlib::is_whitespace(at(pos)))
                 break;
         }
         if (pos >= length())
@@ -194,7 +194,7 @@ cview cview::view_digit(size_t start) const
 {
     for (; start < length(); ++start)
     {
-        if (ttlib::isdigit(at(start)))
+        if (ttlib::is_digit(at(start)))
             return subview(start);
     }
 
@@ -205,7 +205,7 @@ cview cview::view_nondigit(size_t start) const
 {
     for (; start < length(); ++start)
     {
-        if (!ttlib::isdigit(at(start)))
+        if (!ttlib::is_digit(at(start)))
             return subview(start);
     }
 
@@ -219,7 +219,7 @@ bool cview::moveto_digit() noexcept
     size_t pos;
     for (pos = 0; pos < length(); ++pos)
     {
-        if (ttlib::isdigit(at(pos)))
+        if (ttlib::is_digit(at(pos)))
             break;
     }
     if (pos >= length())
@@ -238,7 +238,7 @@ bool cview::moveto_nondigit() noexcept
     size_t pos;
     for (pos = 0; pos < length(); ++pos)
     {
-        if (!ttlib::isdigit(at(pos)))
+        if (!ttlib::is_digit(at(pos)))
             break;
     }
     if (pos >= length())
@@ -341,7 +341,7 @@ ttlib::cview cview::filename() const noexcept
     return { c_str() + pos + 1, length() - (pos + 1) };
 }
 
-bool cview::fileExists() const
+bool cview::file_exists() const
 {
     if (empty())
         return false;
@@ -349,7 +349,7 @@ bool cview::fileExists() const
     return (file.exists() && !file.is_directory());
 }
 
-bool cview::dirExists() const
+bool cview::dir_exists() const
 {
     if (empty())
         return false;
@@ -357,7 +357,7 @@ bool cview::dirExists() const
     return (file.exists() && file.is_directory());
 }
 
-size_t cview::gethash() const noexcept
+size_t cview::get_hash() const noexcept
 {
     if (empty())
         return 0;
@@ -374,7 +374,7 @@ size_t cview::gethash() const noexcept
     return hash;
 }
 
-size_t cview::findoneof(const std::string& set) const
+size_t cview::find_oneof(const std::string& set) const
 {
     if (set.empty())
         return tt::npos;
@@ -384,7 +384,7 @@ size_t cview::findoneof(const std::string& set) const
     return (static_cast<size_t>(pszFound - c_str()));
 }
 
-size_t cview::findspace(size_t start) const
+size_t cview::find_space(size_t start) const
 {
     if (start >= length())
         return npos;
@@ -394,7 +394,7 @@ size_t cview::findspace(size_t start) const
     return (static_cast<size_t>(pszFound - c_str()));
 }
 
-size_t cview::findnonspace(size_t start) const
+size_t cview::find_nonspace(size_t start) const
 {
     for (; start < length(); ++start)
     {
@@ -406,10 +406,10 @@ size_t cview::findnonspace(size_t start) const
 
 size_t cview::stepover(size_t start) const
 {
-    auto pos = findspace(start);
+    auto pos = find_space(start);
     if (pos != npos)
     {
-        pos = findnonspace(pos);
+        pos = find_nonspace(pos);
     }
     return pos;
 }
@@ -462,9 +462,9 @@ std::string_view cview::view_substr(size_t offset, char chBegin, char chEnd)
     }
 
     // step over any leading whitespace unless chBegin is a whitespace character
-    if (!ttlib::iswhitespace(chBegin))
+    if (!ttlib::is_whitespace(chBegin))
     {
-        while (ttlib::iswhitespace(at(offset)))
+        while (ttlib::is_whitespace(at(offset)))
             ++offset;
     }
 

--- a/src/ttlibspace.cpp
+++ b/src/ttlibspace.cpp
@@ -22,19 +22,19 @@ using namespace tt;
 // Global empty string.
 const std::string ttlib::emptystring { std::string() };
 
-const char* ttlib::nextut8fchar(const char* psz) noexcept
+const char* ttlib::next_utf8_char(const char* psz) noexcept
 {
     if (!psz)
         return nullptr;
     if (!*psz)
         return psz;
     size_t i = 0;
-    (void) (ttlib::isutf8(psz[++i]) || ttlib::isutf8(psz[++i]) || ttlib::isutf8(psz[++i]));
+    (void) (ttlib::is_utf8(psz[++i]) || ttlib::is_utf8(psz[++i]) || ttlib::is_utf8(psz[++i]));
 
     return psz + i;
 }
 
-size_t ttlib::gethash(std::string_view str) noexcept
+size_t ttlib::get_hash(std::string_view str) noexcept
 {
     if (str.empty())
         return 0;
@@ -49,14 +49,14 @@ size_t ttlib::gethash(std::string_view str) noexcept
     return hash;
 }
 
-std::string_view ttlib::findspace(std::string_view str) noexcept
+std::string_view ttlib::find_space(std::string_view str) noexcept
 {
     if (str.empty())
         return {};
     size_t pos;
     for (pos = 0; pos < str.length(); ++pos)
     {
-        if (ttlib::iswhitespace(str.at(pos)))
+        if (ttlib::is_whitespace(str.at(pos)))
             break;
     }
     if (pos >= str.length())
@@ -65,23 +65,23 @@ std::string_view ttlib::findspace(std::string_view str) noexcept
         return str.substr(pos);
 }
 
-size_t ttlib::findspace_pos(std::string_view str)
+size_t ttlib::find_space_pos(std::string_view str)
 {
-    auto view = ttlib::findspace(str);
+    auto view = ttlib::find_space(str);
     if (view.empty())
         return tt::npos;
     else
         return (str.size() - view.size());
 }
 
-std::string_view ttlib::findnonspace(std::string_view str) noexcept
+std::string_view ttlib::find_nonspace(std::string_view str) noexcept
 {
     if (str.empty())
         return {};
     size_t pos;
     for (pos = 0; pos < str.length(); ++pos)
     {
-        if (!ttlib::iswhitespace(str.at(pos)))
+        if (!ttlib::is_whitespace(str.at(pos)))
             break;
     }
     if (pos >= str.length())
@@ -90,9 +90,9 @@ std::string_view ttlib::findnonspace(std::string_view str) noexcept
         return str.substr(pos);
 }
 
-size_t ttlib::findnonspace_pos(std::string_view str) noexcept
+size_t ttlib::find_nonspace_pos(std::string_view str) noexcept
 {
-    auto view = ttlib::findnonspace(str);
+    auto view = ttlib::find_nonspace(str);
     if (view.empty())
         return tt::npos;
     else
@@ -107,7 +107,7 @@ std::string_view ttlib::stepover(std::string_view str) noexcept
     size_t pos;
     for (pos = 0; pos < str.length(); ++pos)
     {
-        if (ttlib::iswhitespace(str.at(pos)))
+        if (ttlib::is_whitespace(str.at(pos)))
             break;
     }
     if (pos >= str.length())
@@ -115,7 +115,7 @@ std::string_view ttlib::stepover(std::string_view str) noexcept
 
     for (; pos < str.length(); ++pos)
     {
-        if (!ttlib::iswhitespace(str.at(pos)))
+        if (!ttlib::is_whitespace(str.at(pos)))
             break;
     }
     if (pos >= str.length())
@@ -133,14 +133,14 @@ size_t ttlib::stepover_pos(std::string_view str) noexcept
         return (str.size() - view.size());
 }
 
-ttlib::cview ttlib::viewSpace(const std::string& str, size_t startpos) noexcept
+ttlib::cview ttlib::view_space(const std::string& str, size_t startpos) noexcept
 {
     if (str.empty() || startpos > str.length())
         return ttlib::cview(ttlib::emptystring.c_str(), 0);
     size_t pos;
     for (pos = startpos; pos < str.length(); ++pos)
     {
-        if (ttlib::iswhitespace(str.at(pos)))
+        if (ttlib::is_whitespace(str.at(pos)))
             break;
     }
     if (pos >= str.length())
@@ -149,14 +149,14 @@ ttlib::cview ttlib::viewSpace(const std::string& str, size_t startpos) noexcept
         return ttlib::cview(str.c_str() + pos, str.length() - pos);
 }
 
-ttlib::cview ttlib::viewNonspace(const std::string& str, size_t startpos) noexcept
+ttlib::cview ttlib::view_nonspace(const std::string& str, size_t startpos) noexcept
 {
     if (str.empty())
         return ttlib::cview(ttlib::emptystring.c_str(), 0);
     size_t pos;
     for (pos = startpos; pos < str.length(); ++pos)
     {
-        if (!ttlib::iswhitespace(str.at(pos)))
+        if (!ttlib::is_whitespace(str.at(pos)))
             break;
     }
     if (pos >= str.length())
@@ -165,7 +165,7 @@ ttlib::cview ttlib::viewNonspace(const std::string& str, size_t startpos) noexce
         return ttlib::cview(str.c_str() + pos, str.length() - pos);
 }
 
-ttlib::cview ttlib::viewStepover(const std::string& str, size_t startpos) noexcept
+ttlib::cview ttlib::view_stepover(const std::string& str, size_t startpos) noexcept
 {
     if (str.empty())
         return ttlib::cview(ttlib::emptystring.c_str(), 0);
@@ -173,7 +173,7 @@ ttlib::cview ttlib::viewStepover(const std::string& str, size_t startpos) noexce
     size_t pos;
     for (pos = startpos; pos < str.length(); ++pos)
     {
-        if (ttlib::iswhitespace(str.at(pos)))
+        if (ttlib::is_whitespace(str.at(pos)))
             break;
     }
     if (pos >= str.length())
@@ -181,7 +181,7 @@ ttlib::cview ttlib::viewStepover(const std::string& str, size_t startpos) noexce
 
     for (; pos < str.length(); ++pos)
     {
-        if (!ttlib::iswhitespace(str.at(pos)))
+        if (!ttlib::is_whitespace(str.at(pos)))
             break;
     }
     if (pos >= str.length())
@@ -190,7 +190,7 @@ ttlib::cview ttlib::viewStepover(const std::string& str, size_t startpos) noexce
         return ttlib::cview(str.c_str() + pos, str.length() - pos);
 }
 
-bool ttlib::issameprefix(std::string_view strMain, std::string_view strSub, CASE checkcase)
+bool ttlib::is_sameprefix(std::string_view strMain, std::string_view strSub, CASE checkcase)
 {
     if (strSub.empty())
         return strMain.empty();
@@ -233,7 +233,7 @@ bool ttlib::issameprefix(std::string_view strMain, std::string_view strSub, CASE
     return false;
 }
 
-std::string_view ttlib::findstr(std::string_view main, std::string_view sub, CASE checkcase)
+std::string_view ttlib::find_str(std::string_view main, std::string_view sub, CASE checkcase)
 {
     if (sub.empty())
         return {};
@@ -270,7 +270,7 @@ std::string_view ttlib::findstr(std::string_view main, std::string_view sub, CAS
 
 size_t ttlib::findstr_pos(std::string_view main, std::string_view sub, CASE checkcase)
 {
-    auto view = ttlib::findstr(main, sub, checkcase);
+    auto view = ttlib::find_str(main, sub, checkcase);
     if (view.empty())
         return tt::npos;
     else
@@ -279,10 +279,10 @@ size_t ttlib::findstr_pos(std::string_view main, std::string_view sub, CASE chec
 
 bool ttlib::contains(std::string_view main, std::string_view sub, CASE checkcase)
 {
-    return !ttlib::findstr(main, sub, checkcase).empty();
+    return !ttlib::find_str(main, sub, checkcase).empty();
 }
 
-bool ttlib::issameas(std::string_view str1, std::string_view str2, CASE checkcase)
+bool ttlib::is_sameas(std::string_view str1, std::string_view str2, CASE checkcase)
 {
     if (str1.size() != str2.size())
         return false;
@@ -315,7 +315,7 @@ int ttlib::atoi(std::string_view str) noexcept
     if (str.empty())
         return 0;
 
-    str = ttlib::findnonspace(str);
+    str = ttlib::find_nonspace(str);
 
     int total = 0;
     size_t pos = 0;
@@ -359,7 +359,7 @@ int ttlib::atoi(std::string_view str) noexcept
     return (negative ? -total : total);
 }
 
-std::string_view ttlib::findext(std::string_view str)
+std::string_view ttlib::find_extension(std::string_view str)
 {
     auto pos = str.rfind('.');
     if (pos == std::string_view::npos)
@@ -372,7 +372,7 @@ std::string_view ttlib::findext(std::string_view str)
     return str.substr(pos);
 }
 
-bool ttlib::isvalidfilechar(std::string_view str, size_t pos)
+bool ttlib::is_valid_filechar(std::string_view str, size_t pos)
 {
     if (str.empty() || pos > str.length())
         return false;
@@ -408,14 +408,14 @@ void ttlib::backslashestoforward(std::string& str)
     }
 }
 
-bool ttlib::hasextension(std::filesystem::directory_entry name, std::string_view extension, CASE checkcase)
+bool ttlib::has_extension(std::filesystem::directory_entry name, std::string_view extension, CASE checkcase)
 {
     if (!name.is_directory())
     {
         auto ext = name.path().extension();
         if (ext.empty())
             return false;
-        return ttlib::issameas(ext.string(), extension, checkcase);
+        return ttlib::is_sameas(ext.string(), extension, checkcase);
     }
     return false;
 }
@@ -445,7 +445,7 @@ bool ttlib::ChangeDir(std::string_view newdir)
     return false;
 }
 
-bool ttlib::dirExists(std::string_view dir)
+bool ttlib::dir_exists(std::string_view dir)
 {
     if (dir.empty())
         return false;
@@ -466,7 +466,7 @@ bool ttlib::dirExists(std::string_view dir)
     return false;
 }
 
-bool ttlib::fileExists(std::string_view filename)
+bool ttlib::file_exists(std::string_view filename)
 {
     if (filename.empty())
         return false;

--- a/src/ttparser.cpp
+++ b/src/ttparser.cpp
@@ -31,7 +31,7 @@ cmd::cmd(int argc, wchar_t** argv)
     for (auto argpos = 1; argpos < argc; ++argpos)
     {
         auto& arg = m_originalArgs.emplace_back();
-        arg.assignUTF16(argv[argpos]);
+        arg.from_utf16(argv[argpos]);
     }
     m_hasCommandArgs = true;
 }
@@ -91,7 +91,7 @@ void cmd::addHiddenOption(std::string_view name, size_t flags, size_t setvalue)
 cstr cmd::shortlong(std::string_view name)
 {
     ttlib::cstr result;
-    if (auto pos = name.find('|'); !ttlib::isError(pos))
+    if (auto pos = name.find('|'); !ttlib::is_error(pos))
     {
         std::string shortname;
         shortname.assign(name.substr(0, pos));
@@ -120,7 +120,7 @@ cmd::Option* cmd::findOption(std::string_view option) const
     assert(!option.empty());
 
     ttlib::cstr longname;
-    if (auto pos = option.find('|'); !ttlib::isError(pos))
+    if (auto pos = option.find('|'); !ttlib::is_error(pos))
     {
         longname.assign(option.substr(pos + 1));
     }
@@ -152,7 +152,7 @@ bool cmd::isOption(std::string_view name) const
         {
             return (option->m_result.size());
         }
-        return (!option->m_result.empty() && option->m_result.issameas("true"));
+        return (!option->m_result.empty() && option->m_result.is_sameas("true"));
     }
     return false;
 }
@@ -229,7 +229,7 @@ bool cmd::parse()
                 continue;
             }
 
-            if (arg.issameprefix("?"))
+            if (arg.is_sameprefix("?"))
             {
                 m_HelpRequested = true;
                 continue;

--- a/src/ttstrings.cpp
+++ b/src/ttstrings.cpp
@@ -61,7 +61,7 @@ const char* _tt(const char* str)
 
     for (auto iter = _tt_english->begin(); iter != _tt_english->end(); ++iter)
     {
-        if (ttlib::issameas(iter->second, str))
+        if (ttlib::is_sameas(iter->second, str))
         {
             return _tt(iter->first);
         }
@@ -77,7 +77,7 @@ ttlib::cview _ttv(const char* str)
 
     for (auto iter = _tt_english->begin(); iter != _tt_english->end(); ++iter)
     {
-        if (ttlib::issameas(iter->second, str))
+        if (ttlib::is_sameas(iter->second, str))
         {
             return _ttv(iter->first);
         }
@@ -95,7 +95,7 @@ ttlib::cstr _ttc(const char* str)
 
     for (auto iter = _tt_english->begin(); iter != _tt_english->end(); ++iter)
     {
-        if (ttlib::issameas(iter->second, str))
+        if (ttlib::is_sameas(iter->second, str))
         {
             return _ttc(iter->first);
         }
@@ -115,7 +115,7 @@ std::wstring _ttwx(const char* str)
 
     for (auto iter = _tt_english->begin(); iter != _tt_english->end(); ++iter)
     {
-        if (ttlib::issameas(iter->second, str))
+        if (ttlib::is_sameas(iter->second, str))
         {
             return _ttwx(iter->first);
         }

--- a/src/tttextfile.cpp
+++ b/src/tttextfile.cpp
@@ -134,7 +134,7 @@ size_t textfile::ReplaceInLine(std::string_view orgStr, std::string_view newStr,
     return tt::npos;
 }
 
-bool textfile::issameas(viewfile other, CASE checkcase) const
+bool textfile::is_sameas(viewfile other, CASE checkcase) const
 {
     if (size() != other.size())
         return false;
@@ -142,13 +142,13 @@ bool textfile::issameas(viewfile other, CASE checkcase) const
     size_t pos = 0;
     for (; pos < other.size(); ++pos)
     {
-        if (!at(pos).issameas(other[pos], checkcase))
+        if (!at(pos).is_sameas(other[pos], checkcase))
             break;
     }
     return (pos == size());
 }
 
-bool textfile::issameas(textfile other, CASE checkcase) const
+bool textfile::is_sameas(textfile other, CASE checkcase) const
 {
     if (size() != other.size())
         return false;
@@ -156,7 +156,7 @@ bool textfile::issameas(textfile other, CASE checkcase) const
     size_t pos = 0;
     for (; pos < other.size(); ++pos)
     {
-        if (!at(pos).issameas(other[pos], checkcase))
+        if (!at(pos).is_sameas(other[pos], checkcase))
             break;
     }
     return (pos == size());
@@ -283,7 +283,7 @@ size_t viewfile::FindLineContaining(std::string_view str, size_t start, tt::CASE
     return tt::npos;
 }
 
-bool viewfile::issameas(viewfile other, CASE checkcase) const
+bool viewfile::is_sameas(viewfile other, CASE checkcase) const
 {
     if (size() != other.size())
         return false;
@@ -291,13 +291,13 @@ bool viewfile::issameas(viewfile other, CASE checkcase) const
     size_t pos = 0;
     for (; pos < other.size(); ++pos)
     {
-        if (!ttlib::issameas(at(pos), other[pos], checkcase))
+        if (!ttlib::is_sameas(at(pos), other[pos], checkcase))
             break;
     }
     return (pos == size());
 }
 
-bool viewfile::issameas(textfile other, CASE checkcase) const
+bool viewfile::is_sameas(textfile other, CASE checkcase) const
 {
     if (size() != other.size())
         return false;
@@ -305,7 +305,7 @@ bool viewfile::issameas(textfile other, CASE checkcase) const
     size_t pos = 0;
     for (; pos < other.size(); ++pos)
     {
-        if (!ttlib::issameas(at(pos), other[pos], checkcase))
+        if (!ttlib::is_sameas(at(pos), other[pos], checkcase))
             break;
     }
     return (pos == size());

--- a/src/winsrc/ttdebug.cpp
+++ b/src/winsrc/ttdebug.cpp
@@ -62,7 +62,7 @@ bool ttAssertionMsg(const char* filename, const char* function, int line, const 
     {
         for (auto& iter: ttdbg::g_priorAsserts)
         {
-            if (iter.issameas(msg))
+            if (iter.is_sameas(msg))
                 return false;
         }
         ttdbg::g_priorAsserts.emplace_back(msg);

--- a/src/winsrc/ttdirdlg.cpp
+++ b/src/winsrc/ttdirdlg.cpp
@@ -74,7 +74,7 @@ bool DirDlg::GetFolderName(HWND hwndParent)
                 hr = psiResult->GetDisplayName(SIGDN_FILESYSPATH, &pwszPath);
                 if (SUCCEEDED(hr))
                 {
-                    assignUTF16(pwszPath);
+                    from_utf16(pwszPath);
                     CoTaskMemFree(pwszPath);
                 }
                 psiResult->Release();

--- a/src/winsrc/ttmultibtn.cpp
+++ b/src/winsrc/ttmultibtn.cpp
@@ -26,7 +26,7 @@ BOOL WINAPI ttlib::EnumBtnProc(HWND hwnd, LPARAM lval)
     if ((GetWindowLong(hwnd, GWL_STYLE) & 0x0f) < BS_CHECKBOX)
     {
         GetClassNameA(hwnd, szClass, sizeof(szClass));
-        if (ttlib::issameas(szClass, "Button", tt::CASE::either))
+        if (ttlib::is_sameas(szClass, "Button", tt::CASE::either))
         {
             ttlib::MultiBtn* pMultiBtn = reinterpret_cast<MultiBtn*>(lval);
             ttlib::ShadeBtn* pBtn = new ttlib::ShadeBtn;

--- a/src/winsrc/ttwinspace.cpp
+++ b/src/winsrc/ttwinspace.cpp
@@ -95,17 +95,17 @@ bool ttlib::GetListboxText(HWND hwnd, WPARAM index, std::string& str)
     str.clear();
 
     auto cb = ttlib::SendMsg(hwnd, LB_GETTEXTLEN, index);
-    if (!ttlib::isError(cb))
+    if (!ttlib::is_error(cb))
     {
         auto str16 = std::make_unique<wchar_t[]>(cb + 1);
         cb = ttlib::SendMsg(hwnd, LB_GETTEXT, index, str16.get());
-        if (!ttlib::isError(cb))
+        if (!ttlib::is_error(cb))
         {
             ttlib::utf16to8({ str16.get(), static_cast<size_t>(cb) }, str);
         }
     }
 
-    return !ttlib::isError(cb);
+    return !ttlib::is_error(cb);
 }
 
 ttlib::cstr ttlib::GetComboLBText(HWND hwnd, WPARAM index)
@@ -120,17 +120,17 @@ bool ttlib::GetComboLBText(HWND hwnd, WPARAM index, std::string& str)
     str.clear();
 
     auto cb = ttlib::SendMsg(hwnd, CB_GETLBTEXTLEN, index);
-    if (!ttlib::isError(cb))
+    if (!ttlib::is_error(cb))
     {
         auto str16 = std::make_unique<wchar_t[]>(cb + 1);
         cb = SendMessageW(hwnd, CB_GETLBTEXT, index, (WPARAM) str16.get());
-        if (!ttlib::isError(cb))
+        if (!ttlib::is_error(cb))
         {
             ttlib::utf16to8({ str16.get(), static_cast<size_t>(cb) }, str);
         }
     }
 
-    return !ttlib::isError(cb);
+    return !ttlib::is_error(cb);
 }
 
 void ttlib::SetWndText(HWND hwnd, std::string_view utf8str)
@@ -216,7 +216,7 @@ void ttlib::cmd::WinInit()
     for (auto argpos = 1; argpos < argc; ++argpos)
     {
         auto& arg = m_originalArgs.emplace_back();
-        arg.assignUTF16(argv[argpos]);
+        arg.from_utf16(argv[argpos]);
     }
     LocalFree(argv);
 }
@@ -245,21 +245,21 @@ cstr& cstr::GetListBoxText(HWND hwndCtrl, size_t sel)
 {
     clear();
 
-    if (ttlib::isError(sel))
+    if (ttlib::is_error(sel))
     {
         sel = ttlib::SendMsg(hwndCtrl, LB_GETCURSEL);
-        if (ttlib::isError(sel))
+        if (ttlib::is_error(sel))
         {
             return *this;
         }
     }
 
     auto len = ttlib::SendMsg(hwndCtrl, LB_GETTEXTLEN, sel);
-    if (!ttlib::isError(len))
+    if (!ttlib::is_error(len))
     {
         auto str16 = std::make_unique<wchar_t[]>(len + 1);
         len = SendMsg(hwndCtrl, LB_GETTEXT, sel, str16.get());
-        if (!ttlib::isError(len))
+        if (!ttlib::is_error(len))
         {
             ttlib::utf16to8({ str16.get(), static_cast<size_t>(len) }, *this);
         }
@@ -272,21 +272,21 @@ cstr& cstr::GetComboLBText(HWND hwndCtrl, size_t sel)
 {
     clear();
 
-    if (ttlib::isError(sel))
+    if (ttlib::is_error(sel))
     {
         sel = ttlib::SendMsg(hwndCtrl, CB_GETCURSEL);
-        if (ttlib::isError(sel))
+        if (ttlib::is_error(sel))
         {
             return *this;
         }
     }
 
     auto len = ttlib::SendMsg(hwndCtrl, CB_GETLBTEXTLEN, sel);
-    if (!ttlib::isError(len))
+    if (!ttlib::is_error(len))
     {
         auto str16 = std::make_unique<wchar_t[]>(len + 1);
         len = ttlib::SendMsg(hwndCtrl, CB_GETLBTEXT, sel, str16.get());
-        if (!ttlib::isError(len))
+        if (!ttlib::is_error(len))
         {
             ttlib::utf16to8({ str16.get(), static_cast<size_t>(len) }, *this);
         }


### PR DESCRIPTION
### Fixes #190

### Description:
Switch function names to snake_case.

Note: this needs to be the very last time we make a breaking change like this -- it's an open source library, and once it gets "discovered" then we absolutely cannot make these kinds of changes that break everything.
