### PR TITLE
ttString class

### DIFF
--- a/include/ttstr.h
+++ b/include/ttstr.h
@@ -1,0 +1,275 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Enhanced version of wxString
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2020 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+// This class is only available in ttLibwx.lib (see src/wxsrc) or in a UNIX build.
+
+#pragma once
+
+#if !(__cplusplus >= 201703L || (defined(_MSVC_LANG) && _MSVC_LANG >= 201703L))
+    #error "The ttString class is only available when compiled with C++17 or later."
+#endif
+
+/// @file
+///
+/// The ttString class derives from wxString, adding support for std::string_view and most of the same methods as
+/// ttlib::cstr. Like ttlib::cstr, this class has no data members so it can be used interchangeably with wxString.
+///
+/// On Windows, this class assumes char* and string_view are UTF8 strings and automatically converts them to UTF16
+/// as needed.
+///
+/// Many functions that take a std::string_view parameter will also have an equivalent function taking a "ttString&" or
+/// "wxString&" parameter. Normally this would be a "const ttString&" parameter, however if you do that then the
+/// compiler won't know whether "foo" is supposed to be a std::string view or if it should create a ttString("foo") and
+/// pass that as a const address. That's because wxString has a constructor for "foo" -- which it will NOT convert to
+/// UTF16 on Windows.
+
+#include <wx/string.h>  // wxString class
+
+#include <ttcstr.h>   // cstr -- Classes for handling zero-terminated char strings.
+#include <ttcview.h>  // cview -- string_view functionality on a zero-terminated char string.
+
+/// Version of wxString that supports std::string_view and adds most of the same methods as
+/// ttlib::cstr.
+///
+/// Note: on Windows, this class assumes char* and string_view are UTF8 strings and
+/// automatically converts them to UTF16
+class ttString : public wxString
+{
+public:
+    using wxString::wxString;  // inherit all of wxString's constructors
+
+    ttString(const ttlib::cstr& str) { this->assign(str.wx_str()); }
+    ttString(ttlib::cview str) { this->assign(str.wx_str()); }
+    ttString(void) : wxString() {}
+
+#if defined(_WIN32)
+    // When compiling for Windows, assume all char* are utf8 strings and convert them to utf16 before assigning them.
+
+    ttString(const char* str) { this->assign(ttlib::utf8to16(str)); }
+    ttString(std::string_view str) { this->assign(ttlib::utf8to16(str)); }
+    ttString(std::wstring_view wstr) { this->assign(wstr.data(), wstr.size()); }
+#else
+    ttString(std::string_view str) { this->assign(str.data(), str.size()); }
+#endif  // _WIN32
+
+    /// On Windows, converts to UTF8 before creating a ttlib::cstr copy.
+    ttlib::cstr sub_cstr(size_type pos = 0, size_type count = tt::npos) const;
+
+    ttString& append_view(std::string_view str, size_t posStart = 0, size_t len = npos);
+
+    ttString& assign_view(std::string_view str, size_t posStart = 0, size_t len = npos);
+
+    /// Case-insensitive comparison.
+    int comparei(std::string_view str) const;
+
+    /// Case-insensitive comparison.
+    int comparei(wxString& str) const { return CmpNoCase(str); };
+
+    /// Locates the position of a substring.
+    size_t locate(std::string_view str, size_t posStart = 0, tt::CASE checkcase = tt::CASE::exact) const;
+
+    // Locates the position of a substring.
+    size_t locate(wxString& str, size_t posStart = 0, tt::CASE checkcase = tt::CASE::exact) const;
+
+    /// Returns true if the sub string exists
+    bool contains(std::string_view sub, tt::CASE checkcase = tt::CASE::exact) const { return (locate(sub, 0, checkcase) != npos); }
+
+    // Returns true if the sub string exists
+    bool contains(wxString& sub, tt::CASE checkcase = tt::CASE::exact) const { return (locate(sub, 0, checkcase) != npos); }
+
+    /// Returns true if any string in the iteration list appears somewhere in the the main string.
+    template <class iterT>
+    bool strContains(iterT iter, tt::CASE checkcase = tt::CASE::exact)
+    {
+        for (auto& strIter: iter)
+        {
+            if (contains(strIter, checkcase))
+                return true;
+        }
+        return false;
+    }
+
+    /// Find any one of the characters in a set. Returns offset if found, npos if not.
+    ///
+    /// This is equivalent to calling std::strpbrk but returns an offset instead of a pointer.
+    size_t find_oneof(std::string_view set) const;
+
+#if defined(_WIN32)
+
+    // Find any one of the characters in a set. Returns offset if found, npos if not.
+    //
+    // This is equivalent to calling std::wcspbrk but returns an offset instead of a pointer.
+    size_t find_oneof(std::wstring_view set) const;
+
+#endif
+
+    /// Returns offset to the next whitespace character starting with pos. Returns npos if
+    /// there are no more whitespaces.
+    ///
+    /// A whitespace character is a space, tab, eol or form feed character.
+    size_t find_space(size_t start = 0) const;
+
+    /// Returns a UTF8 copy of the string starting with the next whitespace character after
+    /// pos. Returns an empty string if there are no more whitespaces.
+    ///
+    /// A whitespace character is a space, tab, eol or form feed character.
+    ttlib::cstr sub_find_space(size_t start = 0) const { return sub_cstr(find_space(start)); }
+
+    /// Returns offset to the next non-whitespace character starting with pos. Returns npos
+    /// if there are no more non-whitespace characters.
+    ///
+    /// A whitespace character is a space, tab, eol or form feed character.
+    size_t find_nonspace(size_t start = 0) const;
+
+    /// Returns a UTF8 copy of the string starting with the next non-whitespace character
+    /// after pos. Returns an empty string if there are no more non-whitespaces.
+    ///
+    /// A whitespace character is a space, tab, eol or form feed character.
+    ttlib::cstr sub_find_nonspace(size_t start = 0) const { return sub_cstr(find_nonspace(start)); }
+
+    /// Returns an offset to the next word -- i.e., find the first non-whitespace character
+    /// after the next whitespace character.
+    ///
+    /// Equivalent to find_nonspace(find_space(start)).
+    size_t stepover(size_t start = 0) const;
+
+    /// Returns a UTF8 copy of the string starting with the next word. Returns an empty
+    /// string if there is no next word.
+    ///
+    /// Equivalent to sub_cstr(find_nonspace(find_space(start))).
+    ttlib::cstr sub_stepover(size_t start = 0) const { return sub_cstr(stepover(start)); }
+
+    /// Returns true if the strings are identical.
+    ///
+    /// On Windows, the string will first be converted to UTF16 before comparing.
+    bool is_sameas(std::string_view str, tt::CASE checkcase = tt::CASE::exact) const;
+
+    bool is_sameas(ttString& str, tt::CASE checkcase = tt::CASE::exact) const
+    {
+        return (checkcase == tt::CASE::exact) ? Cmp(str) == 0 : CmpNoCase(str) == 0;
+    }
+
+    /// Returns true if the sub-string is identical to the first part of the main string
+    bool is_sameprefix(std::string_view str, tt::CASE checkcase = tt::CASE::exact) const;
+
+    /// Returns true if the sub-string is identical to the first part of the main string
+    bool is_sameprefix(ttString& str, tt::CASE checkcase = tt::CASE::exact) const;
+
+    int atoi() const
+    {
+        long val;
+        ToLong(&val);
+        return static_cast<int>(val);
+    }
+
+    /// If character is found, line is truncated from the character on, and then any trailing
+    /// space is removed;
+    void erase_from(char ch);
+
+    /// If string is found, line is truncated from the string on, and then any trailing space
+    /// is removed;
+    void erase_from(std::string_view sub);
+
+    /// If string is found, line is truncated from the string on, and then any trailing space
+    /// is removed;
+    void erase_from(ttString& sub);
+
+    /// Replace first (or all) occurrences of substring with another one
+    size_t replace_view(std::string_view oldtext, std::string_view newtext, bool replace_all = tt::REPLACE::once);
+
+#if defined(_WIN32)
+
+    /// Load and assign a string from a Windows resource.
+    ///
+    /// The default is to load from the current executable using the current locale. Call
+    /// ttlib::SetLangInfo() first if you need to load from a different module, or to use
+    /// a different language.
+    ttString& LoadStringEx(WORD idString)
+    {
+        std::string result;
+        ttlib::LoadStringEx(result, idString);
+        assign(ttlib::utf8to16(result));
+        return *this;
+    };
+
+#endif  // _WIN32
+
+    bool is_found(size_t pos) const { return (pos != npos); }
+
+    ///////////////////// filename functions ///////////////////////////
+    //
+    // The following functions assume the current string is a file name.
+    //
+    ////////////////////////////////////////////////////////////////////
+
+    /// Add a trailing forward slash (default is only if there isn't one already). Use this
+    /// function to ensure a directory name will not be interpreted as a file name.
+    void addtrailingslash(bool always = false)
+    {
+        if (always || Last() != '/')
+            *this += '/';
+    }
+
+    /// Converts all backslashes in the string to forward slashes.
+    ///
+    /// Note: Windows API functions work fine with forward slashes instead of backslashes.
+    ttString& backslashestoforward();
+
+    /// ext param should begin with a period (e.g., ".cpp")
+    bool has_extension(std::string_view ext, tt::CASE checkcase = tt::CASE::either) { return extension().is_sameas(ext, checkcase); }
+
+    /// Returns true if current filename contains the specified case-insensitive file name.
+    bool has_filename(std::string_view name, tt::CASE checkcase = tt::CASE::either) const { return filename().is_sameas(name, checkcase); }
+
+    /// Returns a copy of the current extension or wxEmptyStr if there is no extension.
+    ttString extension() const;
+
+    /// Returns a copy of the current filename or wxEmptyStr if there is no filename.
+    ttString filename() const;
+
+    /// Replaces any existing extension with a new extension, or appends the extension if the
+    /// current file name doesn't have an extension.
+    ttString& replace_extension(std::string_view newExtension);
+
+    /// Replaces any existing extension with a new extension, or appends the extension if the
+    /// current file name doesn't have an extension.
+    ttString& replace_extension(ttString& newExtension);
+
+    /// Removes the extension portion of the file name.
+    ttString& remove_extension() { return replace_extension(std::string_view()); };
+
+    ttString& replace_filename(std::string_view newFilename = std::string_view());
+    ttString& replace_filename(ttString& newFilename);
+
+    ttString& remove_filename() { return replace_filename(std::string_view()); };
+
+    /// Appends the file name -- assumes current string is a directory. This will add a
+    /// trailing slash (if needed) before adding the file name.
+    ttString& append_filename(std::string_view filename);
+
+    /// Appends the file name -- assumes current string is a directory. This will add a
+    /// trailing slash (if needed) before adding the filename.
+    ttString& append_filename(ttString& filename);
+
+    /// Replaces current string with the full path to the current working directory.
+    ttString& assignCwd() { assign(wxGetCwd()); return *this; };
+
+    /// Changes any current path to an absolute path.
+    ttString& make_absolute();
+
+    /// Returns the file name which can be used to access this file if the current directory is pathBase
+    ttString& make_relative(ttString& pathBase);
+
+    /// Returns the file name which can be used to access this file if the current directory is pathBase
+    ttString& make_relative(ttlib::cview pathBase);
+
+    /// Returns true if the current string refers to an existing file.
+    bool file_exists() const { return wxFileExists(*this); };
+
+    /// Returns true if the current string refers to an existing directory.
+    bool dir_exists() const { return wxDirExists(*this); };
+};

--- a/src/winsrc/ttdib.cpp
+++ b/src/winsrc/ttdib.cpp
@@ -22,6 +22,14 @@
 
 #include "ttdib.h"
 
+#ifndef max
+    #define max(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
+#ifndef min
+    #define min(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+
 #ifndef WIDTHBYTES
     #define WIDTHBYTES(bits) (((bits) + 31) / 32 * 4)
 #endif

--- a/src/winsrc/ttshadebtn.cpp
+++ b/src/winsrc/ttshadebtn.cpp
@@ -32,6 +32,15 @@
 #include "ttlibspace.h"  // Contains the ttlib namespace functions/declarations common to all ttLib libraries
 #include "ttshadebtn.h"  // ShadeBtn
 
+#ifndef max
+    #define max(a, b) (((a) > (b)) ? (a) : (b))
+#endif
+
+#ifndef min
+    #define min(a, b) (((a) < (b)) ? (a) : (b))
+#endif
+
+
 using namespace ttlib;
 
 ShadeBtn::ShadeBtn()

--- a/src/wxsrc/.srcfiles.yaml
+++ b/src/wxsrc/.srcfiles.yaml
@@ -9,6 +9,7 @@ Options:
     Warn:             4          # [1-4]
 
     CFlags_cmn:       -std:c++17 /Zc:__cplusplus -DUNICODE # flags to pass to the compiler in all builds
+    CFlags_dbg:       -DWXUSINGDLL
 
     Crt_rel:          dll      # [static | dll] type of CRT to link to in release builds
     Crt_dbg:          dll      # [static | dll] type of CRT to link to in debug builds

--- a/src/wxsrc/.srcfiles.yaml
+++ b/src/wxsrc/.srcfiles.yaml
@@ -17,6 +17,8 @@ Options:
     TargetDir:        ../../lib
 
 Files:
+    ttstr.cpp           # Enhanced version of wxString
+
     ../ttconsole.cpp    # class that sets/restores console foreground color
     ../ttcstr.cpp       # Class for handling zero-terminated char strings.
     ../ttcvector.cpp    # Vector class for storing ttlib::cstr strings

--- a/src/wxsrc/precompile/pch.h
+++ b/src/wxsrc/precompile/pch.h
@@ -25,9 +25,23 @@
 
 #define WINVER 0x0A00  // Windows 10
 
-#include <windows.h>
-#include <stdlib.h>
+#define wxUSE_UNICODE     1
+#define wxUSE_NO_MANIFEST 1  // This is required for compiling using CLANG 8 and earlier
 
-#include "ttlibspace.h"
+#include <wx/defs.h>
+
+#define _WX_MISSING_H_  // prevent loading <wx/missing.h> which conflicts with <urlmon.h>
+#include "wx/msw/wrapcctl.h"
+
+#if wxUSE_COMMON_DIALOGS
+    #include <commdlg.h>
+#endif
+
+// Ensure that _DEBUG is defined in non-release builds
+#if !defined(NDEBUG) && !defined(_DEBUG)
+    #define _DEBUG
+#endif
+
+#include <ttlibspace.h>
 
 #undef TT_ASSERT

--- a/src/wxsrc/ttstr.cpp
+++ b/src/wxsrc/ttstr.cpp
@@ -1,0 +1,687 @@
+/////////////////////////////////////////////////////////////////////////////
+// Purpose:   Enhanced version of wxString
+// Author:    Ralph Walden
+// Copyright: Copyright (c) 2020 KeyWorks Software (Ralph Walden)
+// License:   Apache License -- see ../LICENSE
+/////////////////////////////////////////////////////////////////////////////
+
+#include "pch.h"
+
+#include <cwchar>
+#include <cwctype>
+
+#include <wx/filename.h>
+
+#include <ttstr.h>  // ttString
+
+ttlib::cstr ttString::sub_cstr(size_type pos, size_type count) const
+{
+    ttlib::cstr str;
+    if (pos == 0 && count == tt::npos)
+        str.utf(wx_str());
+    else if (pos < size())
+    {
+        wxString tmp(*this, pos, size() - pos);
+
+        // On Windows, this will convert to UTF8, otherwise it's a straight copy of tmp.c_str()
+        str.utf(tmp.wx_str());
+    }
+    return str;
+}
+
+ttString& ttString::append_view(std::string_view str, size_t posStart, size_t len)
+{
+    if (posStart >= str.size())
+    {
+        assertm(posStart < str.size(), "invalid starting position for append_view");
+        return *this;
+    }
+    if (len == npos)
+        len = (str.size() - posStart);
+#if defined(_WIN32)
+    this->append(ttlib::utf8to16(str), posStart, len);
+#else
+    this->append(str.data(), posStart, len);
+#endif  // _WIN32
+    return *this;
+}
+
+ttString& ttString::assign_view(std::string_view str, size_t posStart, size_t len)
+{
+    if (posStart >= str.size())
+    {
+        assertm(posStart < str.size(), "invalid starting position for append_view");
+        return *this;
+    }
+    if (len == npos)
+        len = str.size();
+#if defined(_WIN32)
+    assign(ttlib::utf8to16(str), posStart, len);
+#else
+    this->assign(str.data(), posStart, len);
+#endif  // _WIN32
+    return *this;
+}
+
+int ttString::comparei(std::string_view str) const
+{
+    ttString tmp(str);
+    return CmpNoCase(tmp);
+}
+
+size_t ttString::locate(std::string_view vstr, size_t posStart, tt::CASE checkcase) const
+{
+    if (vstr.empty() || posStart >= size())
+        return npos;
+
+    ttString str(vstr);
+
+    if (checkcase == tt::CASE::exact)
+        return find(str, posStart);
+
+#if defined(_WIN32)
+    // Note that we don't support tt::CASE::utf8 under windows
+
+    auto chLower = std::towlower(str[0]);
+    for (auto pos = posStart; pos < length(); ++pos)
+    {
+        if (std::towlower(at(pos)) == chLower)
+        {
+            size_t posSub;
+            for (posSub = 1; posSub < str.length(); ++posSub)
+            {
+                if (pos + posSub >= length())
+                    return npos;
+                if (std::towlower(at(pos + posSub)) != std::towlower(str.at(posSub)))
+                    break;
+            }
+            if (posSub >= str.length())
+                return pos;
+        }
+    }
+
+#else
+    if (checkcase == tt::CASE::either)
+    {
+        auto chLower = std::tolower(str[0]);
+        for (auto pos = posStart; pos < length(); ++pos)
+        {
+            if (std::tolower(at(pos)) == chLower)
+            {
+                size_t posSub;
+                for (posSub = 1; posSub < str.length(); ++posSub)
+                {
+                    if (pos + posSub >= length())
+                        return npos;
+                    if (std::tolower(at(pos + posSub)) != std::tolower(str.at(posSub)))
+                        break;
+                }
+                if (posSub >= str.length())
+                    return pos;
+            }
+        }
+    }
+    else
+    {
+        auto utf8locale = std::locale("en_US.utf8");
+        auto chLower = std::tolower(str[0], utf8locale);
+        for (auto pos = posStart; pos < length(); ++pos)
+        {
+            if (std::tolower(at(pos), utf8locale) == chLower)
+            {
+                size_t posSub;
+                for (posSub = 1; posSub < str.length(); ++posSub)
+                {
+                    if (pos + posSub >= length())
+                        return npos;
+                    if (std::tolower(at(pos + posSub), utf8locale) != std::tolower(str.at(posSub), utf8locale))
+                        break;
+                }
+                if (posSub >= str.length())
+                    return pos;
+            }
+        }
+    }
+
+#endif  // _WIN32
+
+    return npos;
+}
+
+size_t ttString::locate(wxString& str, size_t posStart, tt::CASE checkcase) const
+{
+    if (str.empty() || posStart >= size())
+        return npos;
+
+    if (checkcase == tt::CASE::exact)
+        return find(str, posStart);
+
+#if defined(_WIN32)
+    auto chLower = std::towlower(str[0]);
+    for (auto pos = posStart; pos < length(); ++pos)
+    {
+        if (std::towlower(at(pos)) == chLower)
+        {
+            size_t posSub;
+            for (posSub = 1; posSub < str.length(); ++posSub)
+            {
+                if (pos + posSub >= length())
+                    return npos;
+                if (std::towlower(at(pos + posSub)) != std::towlower(str.at(posSub)))
+                    break;
+            }
+            if (posSub >= str.length())
+                return pos;
+        }
+    }
+#else
+    auto chLower = std::tolower(str[0]);
+    for (auto pos = posStart; pos < length(); ++pos)
+    {
+        if (std::tolower(at(pos)) == chLower)
+        {
+            size_t posSub;
+            for (posSub = 1; posSub < str.length(); ++posSub)
+            {
+                if (pos + posSub >= length())
+                    return npos;
+                if (std::tolower(at(pos + posSub)) != std::tolower(str.at(posSub)))
+                    break;
+            }
+            if (posSub >= str.length())
+                return pos;
+        }
+    }
+#endif  // _WIN32
+
+    return npos;
+}
+
+size_t ttString::find_oneof(std::string_view set) const
+{
+    if (set.empty())
+        return npos;
+
+#if defined(_WIN32)
+    auto wset = ttlib::utf8to16(set);
+#else
+    std::string wset(set);
+#endif  // _WIN32
+
+    auto found = std::wcspbrk(c_str(), wset.c_str());
+    if (!found)
+        return npos;
+    return (static_cast<size_t>(found - c_str()));
+}
+
+#if defined(_WIN32)
+
+size_t ttString::find_oneof(std::wstring_view set) const
+{
+    if (set.empty())
+        return npos;
+
+    auto wset = std::wstring(set);
+    auto found = std::wcspbrk(c_str(), wset.c_str());
+    if (!found)
+        return npos;
+    return (static_cast<size_t>(found - c_str()));
+}
+
+#endif
+
+size_t ttString::find_space(size_t start) const
+{
+    if (start >= length())
+        return npos;
+
+#if defined(_WIN32)
+    auto found = std::wcspbrk(c_str() + start, L" \t\r\n\f");
+#else
+    auto found = std::strpbrk(c_str() + start, " \t\r\n\f");
+#endif
+    if (!found)
+        return npos;
+    return (static_cast<size_t>(found - c_str()));
+}
+
+size_t ttString::find_nonspace(size_t start) const
+{
+    for (; start < size(); ++start)
+    {
+#if defined(_WIN32)
+        if (!std::wcschr(L" \t\r\n\f", at(start)))
+            break;
+#else
+        if (!std::strchr(" \t\r\n\f", at(start)))
+            break;
+#endif
+    }
+    return start;
+}
+
+size_t ttString::stepover(size_t start) const
+{
+    auto pos = find_space(start);
+    if (pos != npos)
+    {
+        pos = find_nonspace(pos);
+    }
+    return pos;
+}
+
+bool ttString::is_sameas(std::string_view str, tt::CASE checkcase) const
+{
+    if (size() != str.size())
+        return false;
+
+    if (empty())
+        return str.empty();
+
+    // if both strings have the same length and are non-empty, then we can compare as a prefix.
+    return is_sameprefix(str, checkcase);
+}
+
+bool ttString::is_sameprefix(std::string_view vstr, tt::CASE checkcase) const
+{
+    if (vstr.empty())
+        return empty();
+
+    if (empty() || size() < vstr.size())
+        return false;
+
+#if defined(_WIN32)
+    auto str = ttlib::utf8to16(vstr);
+#else
+    std::string str(vstr);
+#endif  // _WIN32
+
+    if (checkcase == tt::CASE::exact)
+    {
+        auto iterMain = begin();
+        for (auto iterSub: str)
+        {
+            if (*iterMain++ != iterSub)
+                return false;
+        }
+        return true;
+    }
+    else
+    {
+        auto iterMain = begin();
+        for (auto iterSub: str)
+        {
+#if defined(_WIN32)
+            if (std::towlower(*iterMain++) != std::towlower(iterSub))
+                return false;
+#else
+            if (std::tolower(*iterMain++) != std::tolower(iterSub))
+                return false;
+#endif
+        }
+        return true;
+    }
+
+    return false;
+}
+
+bool ttString::is_sameprefix(ttString& str, tt::CASE checkcase) const
+{
+    if (str.empty())
+        return empty();
+
+    if (empty() || size() < str.size())
+        return false;
+
+    if (checkcase == tt::CASE::exact)
+    {
+        auto iterMain = begin();
+        for (auto iterSub: str)
+        {
+            if (*iterMain++ != iterSub)
+                return false;
+        }
+        return true;
+    }
+    else
+    {
+        auto iterMain = begin();
+        for (auto iterSub: str)
+        {
+#if defined(_WIN32)
+            if (std::towlower(*iterMain++) != std::towlower(iterSub))
+                return false;
+#else
+            if (std::tolower(*iterMain++) != std::tolower(iterSub))
+                return false;
+#endif  // _WIN32
+        }
+        return true;
+    }
+}
+
+ttString& ttString::backslashestoforward()
+{
+    for (auto pos = find('\\'); pos != wxString::npos; pos = find('\\'))
+    {
+        replace(pos, 1, "/");
+    }
+    return *this;
+}
+
+ttString ttString::extension() const
+{
+    if (empty())
+        return wxEmptyString;
+
+    auto pos = find_last_of('.');
+    if (!is_found(pos))
+        return wxEmptyString;
+
+    // . by itself is a folder
+    else if (pos + 1 >= length())
+        return wxEmptyString;
+
+    // .. is not a valid extension (it's usually part of a folder as in "../dir/")
+    else if (c_str()[pos + 1] == '.')
+        return wxEmptyString;
+
+    ttString dest(*this, pos, size() - pos);
+    return dest;
+}
+
+ttString ttString::filename() const
+{
+    if (empty())
+        return wxEmptyString;
+
+    auto pos = find_last_of('/');
+
+#if defined(_WIN32)
+    // Windows filenames can contain both forward and back slashes, so check for a backslash as well.
+    auto back = find_last_of('\\');
+    if (back != npos)
+    {
+        // If there is no forward slash, or the backslash appears after the forward slash, then use it's position.
+        if (pos == npos || back > pos)
+            pos = back;
+    }
+#endif
+
+    if (pos == npos)
+    {
+        pos = find_last_of(':');
+        if (pos == npos)
+        {
+            ttString dest(*this);
+            return dest;
+        }
+    }
+
+    ttString dest(*this, pos + 1, size() - (pos + 1));
+    return dest;
+}
+
+void ttString::erase_from(char ch)
+{
+    if (auto pos = find(ch); pos != npos)
+    {
+        erase(pos);
+        Trim();
+    }
+}
+
+void ttString::erase_from(std::string_view sub)
+{
+#if defined(_WIN32)
+    auto pos = find(ttlib::utf8to16(sub));
+#else
+    auto pos = find(sub.data(), 0, sub.size());
+#endif  // _WIN32
+    if (pos != npos)
+    {
+        erase(pos);
+        Trim();
+    }
+}
+
+void ttString::erase_from(ttString& sub)
+{
+    if (auto pos = find(sub); pos != npos)
+    {
+        erase(pos);
+        Trim();
+    }
+}
+
+size_t ttString::replace_view(std::string_view oldtext, std::string_view newtext, bool replace_all)
+{
+#if defined(_WIN32)
+    auto old_text = ttlib::utf8to16(oldtext);
+    auto replace_text = ttlib::utf8to16(newtext);
+#else
+    ttlib::cstr old_text(oldtext);
+    ttlib::cstr replace_text(newtext);
+#endif  // _WIN32
+
+    return Replace(old_text, replace_text, replace_all);
+}
+
+ttString& ttString::replace_extension(std::string_view newExtension)
+{
+    if (empty())
+    {
+        if (newExtension.empty())
+            return *this;
+        if (newExtension.at(0) != '.')
+            *this = '.';
+        append_view(newExtension);
+        return *this;
+    }
+
+    if (auto pos = find_last_of('.'); is_found(pos))
+    {
+        // If the string only contains . or .. then it is a folder
+        if (pos == 0 || (pos == 1 && at(0) != '.'))
+            return *this;  // can't add an extension if it isn't a valid filename
+
+        if (newExtension.empty())
+        {
+            // If the new extension is empty, then just erase the old extension.
+            erase(pos);
+        }
+        else
+        {
+            erase(pos);
+            if (newExtension.at(0) != '.')
+                *this += '.';
+            append_view(newExtension);
+        }
+    }
+    else if (newExtension.size())
+    {
+        // Current filename doesn't have an extension, so append the new one
+        if (newExtension.at(0) != '.')
+            *this += '.';
+        append_view(newExtension);
+    }
+
+    return *this;
+}
+
+ttString& ttString::replace_extension(ttString& newExtension)
+{
+    if (empty())
+    {
+        if (newExtension.empty())
+            return *this;
+        if (newExtension.at(0) != '.')
+            *this = '.';
+        append(newExtension);
+        return *this;
+    }
+
+    if (auto pos = find_last_of('.'); is_found(pos))
+    {
+        // If the string only contains . or .. then it is a folder
+        if (pos == 0 || (pos == 1 && at(0) != '.'))
+            return *this;  // can't add an extension if it isn't a valid filename
+
+        if (newExtension.empty())
+        {
+            // If the new extension is empty, then just erase the old extension.
+            erase(pos);
+        }
+        else
+        {
+            erase(pos);
+            if (newExtension.at(0) != '.')
+                *this += '.';
+            append(newExtension);
+        }
+    }
+    else if (newExtension.size())
+    {
+        // Current filename doesn't have an extension, so append the new one
+        if (newExtension.at(0) != '.')
+            *this += '.';
+        append(newExtension);
+    }
+
+    return *this;
+}
+
+ttString& ttString::replace_filename(std::string_view newFilename)
+{
+    if (empty())
+    {
+        assign_view(newFilename);
+        return *this;
+    }
+
+    auto pos = find_last_of('/');
+
+#if defined(_WIN32)
+    // Windows filenames can contain both forward and back slashes, so check for a backslash as well.
+    auto back = find_last_of('\\');
+    if (back != npos)
+    {
+        // If there is no forward slash, or the backslash appears after the forward slash, then use it's position.
+        if (pos == npos || back > pos)
+            pos = back;
+    }
+#endif
+    if (pos == npos)
+    {
+        pos = find_last_of(':');
+        if (pos == npos)
+        {
+            // If we get here, we think the entire current string is a filename.
+            assign_view(newFilename);
+            return *this;
+        }
+    }
+
+    erase(pos + 1);
+    if (newFilename.size())
+        append_view(newFilename);
+    return *this;
+}
+
+ttString& ttString::replace_filename(ttString& newFilename)
+{
+    if (empty())
+    {
+        assign(newFilename);
+        return *this;
+    }
+
+    auto pos = find_last_of('/');
+
+#if defined(_WIN32)
+    // Windows filenames can contain both forward and back slashes, so check for a backslash as well.
+    auto back = find_last_of('\\');
+    if (back != npos)
+    {
+        // If there is no forward slash, or the backslash appears after the forward slash, then use it's position.
+        if (pos == npos || back > pos)
+            pos = back;
+    }
+#endif
+    if (pos == npos)
+    {
+        pos = find_last_of(':');
+        if (pos == npos)
+        {
+            // If we get here, we think the entire current string is a filename.
+            assign(newFilename);
+            return *this;
+        }
+    }
+
+    erase(pos + 1);
+    if (newFilename.size())
+        append(newFilename);
+    return *this;
+}
+
+ttString& ttString::append_filename(std::string_view filename)
+{
+    if (filename.empty())
+        return *this;
+    if (empty())
+    {
+        assign_view(filename);
+        return *this;
+    }
+
+    auto last = Last();
+    if (last != '/' && last != '\\')
+        *this += '/';
+    append_view(filename);
+    return *this;
+}
+
+ttString& ttString::append_filename(ttString& filename)
+{
+    if (filename.empty())
+        return *this;
+    if (empty())
+    {
+        assign(filename);
+        return *this;
+    }
+
+    auto last = Last();
+    if (last != '/' && last != '\\')
+        *this += '/';
+    append(filename);
+    return *this;
+}
+
+ttString& ttString::make_absolute()
+{
+    wxFileName file(*this);
+    file.MakeAbsolute();
+
+    assign(file.GetFullPath());
+    return *this;
+}
+
+ttString& ttString::make_relative(ttString& pathBase)
+{
+    wxFileName file(*this);
+    file.MakeRelativeTo(pathBase);
+
+    assign(file.GetFullPath());
+    return *this;
+}
+
+ttString& ttString::make_relative(ttlib::cview pathBase)
+{
+    wxFileName file(*this);
+    file.MakeRelativeTo(pathBase.wx_str());  // On Windows, will convert to UTF16
+
+    assign(file.GetFullPath());
+    return *this;
+}


### PR DESCRIPTION

### Description:
This adds a `ttString` class that derives from `wxString`. It provides all of the functionality of `wxString` plus support for `std::string_view` and most of the identical methods in `ttlib::cstr`.

This fixes the problems that occurred once we added a module that requires **wxWidgets**. Note that this also requires setting static or dynamic **wxWidgets** libraries. For now, I went with dll for debug builds and static for release builds. Unfortunately, that means all projects linking to this library must do the same -- at least until we figure out a different way of building that avoids that limitation.
