### PR TITLE
Add strContains and strContains_wx

### DIFF
--- a/include/ttstr.h
+++ b/include/ttstr.h
@@ -83,6 +83,32 @@ public:
     // Returns true if the sub string exists
     bool contains_wx(const wxString& sub, tt::CASE checkcase = tt::CASE::exact) const { return (locate_wx(sub, 0, checkcase) != npos); }
 
+    /// Returns true if any char* string in the iteration list appears somewhere in the the
+    /// main string.
+    template<class iterT>
+    bool strContains(iterT iter, tt::CASE checkcase = tt::CASE::exact)
+    {
+        for (auto& strIter: iter)
+        {
+            if (contains(strIter, checkcase))
+                return true;
+        }
+        return false;
+    }
+
+    /// Returns true if any wxString in the iteration list appears somewhere in the the main
+    /// string.
+    template<class iterT>
+    bool strContains_wx(iterT iter, tt::CASE checkcase = tt::CASE::exact)
+    {
+        for (auto& strIter: iter)
+        {
+            if (contains_wx(strIter, checkcase))
+                return true;
+        }
+        return false;
+    }
+
     /// Find any one of the characters in a set. Returns offset if found, npos if not.
     ///
     /// This is equivalent to calling std::strpbrk but returns an offset instead of a pointer.


### PR DESCRIPTION
### Fixes #

### Description:
This PR adds `strContains` and `strContains_wx` functions to the `ttString` class. These templated functions are so that you can iterate through multiple strings and return `true` if any of the strings are contained within the `ttString`. An example usage is as follows:

```c++
    constexpr const auto batchTypes = { ".bat", ".btm", ".cmd" };

    ttString my_file("some filename");

    if (my_file.strContains(batchTypes, tt::CASE::either))
    {
        // Process as a Windows batch file
```


