### PR TITLE
Check for empty() when trimming both sides

### DIFF
--- a/src/ttcstr.cpp
+++ b/src/ttcstr.cpp
@@ -116,7 +116,9 @@ cstr& cstr::trim(tt::TRIM where)
         if (len + 1 < length())
             erase(len + 1, length() - len);
     }
-    if (where == tt::TRIM::left || where == tt::TRIM::both)
+
+    // If trim(right) was called above, the string may now be empty -- front() fails on an empty string
+    if (!empty() && (where == tt::TRIM::left || where == tt::TRIM::both))
     {
         // Assume that most strings won't start with whitespace, so return as quickly as possible if that is the
         // case.
@@ -131,6 +133,7 @@ cstr& cstr::trim(tt::TRIM where)
         }
         replace(0, length(), substr(pos, length() - pos));
     }
+
     return *this;
 }
 


### PR DESCRIPTION
Fixes #198

Trim right happens first which can result in an empty string before trim left is processed.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
