### PR TITLE
Refactor and optimized ttlib::cstr and ttString

### DIFF
--- a/include/ttstr.h
+++ b/include/ttstr.h
@@ -1,5 +1,5 @@
 /////////////////////////////////////////////////////////////////////////////
-// Purpose:   Enhanced version of wxString
+// Purpose:   wxString with additional methods similar to ttlib::cstr
 // Author:    Ralph Walden
 // Copyright: Copyright (c) 2020 KeyWorks Software (Ralph Walden)
 // License:   Apache License -- see ../LICENSE
@@ -46,14 +46,14 @@ public:
     ttString(const wxString& str) : wxString(str) {}
     ttString(void) : wxString() {}
 
-    ttString(const ttlib::cstr& str) { this->assign(str.wx_str()); }
-    ttString(ttlib::cview str) { this->assign(str.wx_str()); }
+    ttString(const ttlib::cstr& str);
+    ttString(ttlib::cview str);
 
 #if defined(_WIN32)
     // When compiling for Windows, assume all char* are utf8 strings and convert them to utf16 before assigning them.
 
-    ttString(const char* str) { this->assign(ttlib::utf8to16(str)); }
-    ttString(std::string_view str) { this->assign(ttlib::utf8to16(str)); }
+    ttString(const char* str) { this->assign(wxString::FromUTF8(str)); }
+    ttString(std::string_view str) { this->assign(wxString::FromUTF8(str.data(), str.size())); }
 #else
     ttString(std::string_view str) { this->assign(str.data(), str.size()); }
 #endif  // _WIN32
@@ -178,16 +178,13 @@ public:
         return static_cast<int>(val);
     }
 
-    /// If character is found, line is truncated from the character on, and then any trailing
-    /// space is removed;
+    /// If character is found, line is truncated from the character on
     void erase_from(char ch);
 
-    /// If string is found, line is truncated from the string on, and then any trailing space
-    /// is removed;
+    /// If string is found, line is truncated from the string on
     void erase_from(std::string_view sub);
 
-    /// If string is found, line is truncated from the string on, and then any trailing space
-    /// is removed;
+    /// If string is found, line is truncated from the string on
     void erase_from_wx(const wxString& sub);
 
     /// Replace first (or all) occurrences of substring with another one

--- a/src/ttcstr.cpp
+++ b/src/ttcstr.cpp
@@ -1046,3 +1046,48 @@ cstr& cdecl cstr::Format(std::string_view format, ...)
 
     return *this;
 }
+
+/////////////////// The following section is only built when building with wxWidgets header files ///////////////////
+
+// clang-format off
+#if defined(_WX_DEFS_H_)
+
+#include <wx/string.h>  // wxString class
+
+#if defined(_WIN32)
+    // This ctor is only available on Windows builds where wxString is UTF16. For non-Windows builds,
+    // a ctor for std::wstring_view is used insted.
+
+    cstr::cstr(const wxString& str)
+    {
+    #if defined(_WIN32)
+        utf16to8(str.wx_str(), *this);
+    #else
+        *this = str.c_str();
+    #endif
+}
+#endif  // _WIN32
+
+cstr& cstr::assign_wx(const wxString& str)
+{
+#if defined(_WIN32)
+    clear();
+    utf16to8(str.wx_str(), *this);
+#else
+    *this = str.c_str();
+#endif
+    return *this;
+}
+
+cstr& cstr::append_wx(const wxString& str)
+{
+#if defined(_WIN32)
+    utf16to8(str.wx_str(), *this);
+#else
+    *this += str.c_str();
+#endif
+    return *this;
+}
+// clang-format on
+
+#endif  // _WX_DEFS_H_


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR refactors and expands UTF conversions in `ttlib::cstr` and `ttString`. In both cases, conversion from UTF16 to UTF8 is now usually done without allocating a copy of the string first.

## ttlib::cstr

- The constructor for wide strings is now conditionalized. If `_WX_DEFS_H_` (wx/defs.h) and `_WIN32` is defined then the constructor for `std::wstring_view` is replaced with `const wxString&`.
- Conversion from a UTF16 string is now down without allocating a copy of the UTF16 string.
- `assign_wx` and `append_wx` methods added for assigning/appending `wxStrings` without requiring a `.wx_str()`.

## ttString

- Constructors added for ttlib::cstr and ttlib::cview
- Constructors for char* and std::string_view now call `wxString::FromUTF8()` instead of `ttlib::utf8to16`
- `erase_from` methods no longer call `Trim()` -- automatically calling `Trim()` eliminates the possibility of leaving trailing spaces before appending different text.
- refactored `is_sameas` to eliminate bug with `size()` comparisons
- optimized `replace_view` to use `wxString` built-in conversions
