### PR TITLE
Add find_oneof to locate one of a set of chars

### DIFF
--- a/include/ttcstr.h
+++ b/include/ttcstr.h
@@ -121,6 +121,11 @@ namespace ttlib
         /// This is equivalent to calling std::strpbrk but returns an offset instead of a pointer.
         size_t find_oneof(const char* pszSet) const;
 
+        /// Find any one of the characters in a set. Returns offset if found, npos if not.
+        ///
+        /// This is equivalent to calling std::strpbrk but returns an offset instead of a pointer.
+        size_t find_oneof(cview set, size_t start) const;
+
         /// Returns offset to the next whitespace character starting with pos. Returns npos if
         /// there are no more whitespaces.
         ///

--- a/include/ttcview.h
+++ b/include/ttcview.h
@@ -102,6 +102,11 @@ namespace ttlib
         /// This is equivalent to calling std::strpbrk but returns an offset instead of a pointer.
         size_t find_oneof(const std::string& set) const;
 
+        /// Find any one of the characters in a set. Returns offset if found, npos if not.
+        ///
+        /// This is equivalent to calling std::strpbrk but returns an offset instead of a pointer.
+        size_t find_oneof(cview set, size_t start) const;
+
         /// Returns offset to the next whitespace character starting with pos. Returns npos if
         /// there are no more whitespaces.
         ///

--- a/src/ttcstr.cpp
+++ b/src/ttcstr.cpp
@@ -652,6 +652,17 @@ size_t cstr::find_oneof(const char* pszSet) const
     return (static_cast<size_t>(pszFound - c_str()));
 }
 
+size_t cstr::find_oneof(cview set, size_t start) const
+{
+    if (set.empty())
+        return tt::npos;
+    auto view_start = subview(start);
+    const char* pszFound = std::strpbrk(view_start, set);
+    if (!pszFound)
+        return tt::npos;
+    return (static_cast<size_t>(pszFound - view_start.c_str()));
+}
+
 size_t cstr::find_space(size_t start) const
 {
     if (start >= length())

--- a/src/ttcview.cpp
+++ b/src/ttcview.cpp
@@ -384,6 +384,17 @@ size_t cview::find_oneof(const std::string& set) const
     return (static_cast<size_t>(pszFound - c_str()));
 }
 
+size_t cview::find_oneof(cview set, size_t start) const
+{
+    if (set.empty())
+        return tt::npos;
+    auto view_start = subview(start);
+    const char* pszFound = std::strpbrk(view_start, set);
+    if (!pszFound)
+        return tt::npos;
+    return (static_cast<size_t>(pszFound - view_start.c_str()));
+}
+
 size_t cview::find_space(size_t start) const
 {
     if (start >= length())


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This variation of `find_oneof` adds a starting position position, and uses a ttlib::cview as the set instead of a `const char*`. The start position makes it possible to iterate over multiple found positions, similar to what `ttlib::multistr` does with a single character.