### PR TITLE
Correctly append extension in path with a dir containing a period

### DIFF
--- a/include/ttstr.h
+++ b/include/ttstr.h
@@ -247,6 +247,9 @@ public:
     /// Returns a copy of the current filename or wxEmptyStr if there is no filename.
     ttString filename() const;
 
+    /// Returns offset to the current filename or tt::npos if there is no filename.
+    size_t find_filename() const noexcept;
+
     /// Replaces any existing extension with a new extension, or appends the extension if the
     /// current file name doesn't have an extension.
     ttString& replace_extension(std::string_view newExtension);

--- a/src/ttcstr.cpp
+++ b/src/ttcstr.cpp
@@ -444,7 +444,11 @@ cstr& cstr::replace_extension(std::string_view newExtension)
         return *this;
     }
 
-    if (auto pos = find_last_of('.'); ttlib::is_found(pos))
+    auto pos_file = find_filename();
+    if (ttlib::is_error(pos_file))
+        pos_file = 0;
+
+    if (auto pos = find_last_of('.'); ttlib::is_found(pos) && pos > pos_file)
     {
         // If the string only contains . or .. then it is a folder
         if (pos == 0 || (pos == 1 && at(0) != '.'))


### PR DESCRIPTION
Fixes #205

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR fixes the problem where a path contains a directory with a period, but the filename does not have an extension, and `replace_extension` is called.

For `ttString` I added `find_filename` since that's the function needed to confirm that the last period appears after the start of the filename, not before.
