### PR TITLE
Add locale-dependent inline trim functions

### DIFF
--- a/include/ttcstr.h
+++ b/include/ttcstr.h
@@ -168,6 +168,25 @@ namespace ttlib
         /// where: TRIM::right, TRIM::left, or TRIM::both
         cstr& trim(tt::TRIM where = tt::TRIM::right);
 
+        /// Remove locale-dependent whitespace from right side
+        inline void RightTrim()
+        {
+            erase(std::find_if(rbegin(), rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), end());
+        }
+
+        /// Remove locale-dependent whitespace from left side
+        inline void LeftTrim()
+        {
+            erase(begin(), std::find_if(begin(), end(), [](unsigned char ch) { return !std::isspace(ch); }));
+        }
+
+        /// Remove locale-dependent whitespace from left and right side
+        inline void BothTrim()
+        {
+            LeftTrim();
+            RightTrim();
+        }
+
         /// Returns a view of the characters between chBegin and chEnd. This is typically used
         /// to view the contents of a quoted string. Returns the position of the ending
         ///  character in src.

--- a/include/ttlibspace.h
+++ b/include/ttlibspace.h
@@ -249,6 +249,24 @@ namespace ttlib
     std::wstring utf8to16(std::string_view str);
     ttlib::cstr utf16to8(std::wstring_view str);
 
+    /// Remove locale-dependent whitespace from right side of string
+    inline void RightTrim(std::string& s)
+    {
+        s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(), s.end());
+    }
+
+    /// Remove locale-dependent whitespace from left side of string
+    inline void LeftTrim(std::string& s)
+    {
+        s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) { return !std::isspace(ch); }));
+    }
+
+    /// Remove locale-dependent whitespace from left and right side of string
+    inline void BothTrim(std::string& s)
+    {
+        ttlib::LeftTrim(s);
+        ttlib::RightTrim(s);
+    }
 }  // namespace ttlib
 
 // clang-format off
@@ -354,7 +372,7 @@ namespace ttlib
 
     /// Only available in ttLibwx.lib (wxWidgets + Windows)
     HINSTANCE ShellRun_wx(const wxString& filename, const wxString& args, const wxString& directory, INT nShow = SW_SHOWNORMAL,
-                       HWND hwndParent = NULL);
+                          HWND hwndParent = NULL);
 
     HFONT CreateLogFont(std::string_view TypeFace, size_t point, bool Bold = false, bool Italics = false);
 


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds locale-aware `inline` trim functions that can trim a `std::string` (or `ttlib::cstr`) in place.

`ttlib::cstr` already has a `trim()` function, however it is not locale-aware and may be incorrect in some locales. I left that code untouched, and for the new methods, added the comment that they are locale-dependent.

This also adds the functions to the `ttlib::` namespace which work on any `std::string` not just the `ttlib::cstr` derived class.