### PR TITLE
Add == (ttlib::cview) operator to cview class

### DIFF
--- a/include/ttcview.h
+++ b/include/ttcview.h
@@ -206,5 +206,11 @@ namespace ttlib
         /// A filename is any string after the last '/' (or '\' on Windows) in the current
         /// view.
         bool moveto_filename() noexcept;
+
+        bool operator==(ttlib::cview str)
+        {
+            return this->is_sameas(str);
+        }
+
     };
 }  // namespace ttlib


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a `==` operator to the cview class so that comparison between two cview classes can be done with `==` instead of calling `is_sameas()`. In most cases the compiler will convert a literal string to a cview in order to do the comparison. Note that you can _not_ use this operator to compare with a `std::string_view` -- this operator requires a null-terminated string on the right side.
