### PR TITLE
Wx32

### DIFF
--- a/src/ttparser.cpp
+++ b/src/ttparser.cpp
@@ -203,7 +203,7 @@ bool cmd::parse()
             continue;
 
 #if defined(_WIN32)
-        if (arg[0] == '-' || arg[0] == '/')
+        if (arg.at(0) == '-' || arg.at(0) == '/')
 #else
         if (arg[0] == '-')
 #endif  // _WIN32
@@ -211,7 +211,7 @@ bool cmd::parse()
             arg.remove_prefix(1);
 
             // long names are sometimes specified with -- so remove the second hyphen if that's the case
-            if (arg[0] == '-')
+            if (arg.at(0) == '-')
                 arg.remove_prefix(1);
 
             // If the argument is followed by a quote, then add it whether this is an argument type or not
@@ -271,7 +271,7 @@ bool cmd::parse()
                 arg = m_originalArgs[argpos].subview();
 
 #if defined(_WIN32)
-                if (arg.empty() || arg[0] == '-' || arg[0] == '/')
+                if (arg.empty() || arg.at(0) == '-' || arg.at(0) == '/')
 #else
                 if (arg.empty() || arg[0] == '-')
 #endif  // _WIN32
@@ -293,7 +293,7 @@ bool cmd::parse()
         }
         else
         {
-            if (arg[0] == '"')
+            if (arg.at(0) == '"')
             {
                 auto entry = m_extras.emplace_back();
                 entry.ExtractSubString(arg);

--- a/src/win32/.srcfiles.yaml
+++ b/src/win32/.srcfiles.yaml
@@ -29,8 +29,7 @@ Files:
     ../ttsvector.cpp    # Vector class for storing ttString strings
     ../tttextfile.cpp   # Classes for reading and writing text files.
 
-    # Disabled due to compiler errors when compiling for 32-bit
-    # ../ttparser.cpp     # Command line parser
+    ../ttparser.cpp     # Command line parser
 
 # Windows only files
 

--- a/src/wxwin32/.srcfiles.yaml
+++ b/src/wxwin32/.srcfiles.yaml
@@ -1,0 +1,50 @@
+# Requires ttBld.exe version 1.4.0 or higher to process -- see https://github.com/KeyWorksRW/ttBld
+
+Options:
+    Project:          ttLibwx32  # project target name
+    Exe_type:         lib        # [window | console | lib | dll]
+    Pch:              pch.h      # precompiled header
+    Optimize:         space      # [space | speed] optimization
+    Warn:             4          # [1-4]
+
+    32Bit: true
+
+    CFlags_cmn:       -std:c++17 /Zc:__cplusplus -DUNICODE # flags to pass to the compiler in all builds
+    CFlags_dbg:       -DWXUSINGDLL
+
+    Crt_rel:          dll      # [static | dll] type of CRT to link to in release builds
+    Crt_dbg:          dll      # [static | dll] type of CRT to link to in debug builds
+
+    IncDirs:          ../wxsrc;../../include
+    TargetDir:        ../../lib
+
+Files:
+    ../wxsrc/ttextra.cpp  # Additional functions for wxWidgets on Windows
+
+    ../ttconsole.cpp    # class that sets/restores console foreground color
+    ../ttcstr.cpp       # Class for handling zero-terminated char strings.
+    ../ttcvector.cpp    # Vector class for storing ttlib::cstr strings
+    ../ttcview.cpp      # string_view functionality on a zero-terminated char string.
+    ../ttlibspace.cpp   # ttlib namespace functions
+    ../ttmultistr.cpp   # ttlib::multistr, ttlib::multiview
+    # ../ttparser.cpp     # Command line parser
+    ../ttstr.cpp        # Enhanced version of wxString
+    ../ttstrings.cpp    # Class for handling zero-terminated char strings.
+    ../ttsvector.cpp    # Vector class for storing ttString strings
+    ../tttextfile.cpp   # Classes for reading and writing text files.
+
+# Windows only files
+
+    ../winsrc/ttdib.cpp           # ttCDib class
+    ../winsrc/ttdirdlg.cpp        # dialog for selecting a directory
+    ../winsrc/ttloadstr.cpp       # Load a language-specific version of a string resource
+    ../winsrc/ttmultibtn.cpp      # ttlib::MultiBtn class
+    ../winsrc/ttopenfile.cpp      # Wrapper around Windows GetOpenFileName() API
+    ../winsrc/ttregistry.cpp      # ttlib::registry -- class for working with Windows registry
+    ../winsrc/ttshadebtn.cpp      # ttCShadeBtn class
+    ../winsrc/ttthrdpool.cpp      # ttlib::ThrdPool
+    ../winsrc/ttwin.cpp           # ttlib::win class
+
+    ../winsrc/ttdebug.cpp         # debug and assertion handling
+    ../winsrc/ttwindlg.cpp        # ttlib::dlg -- class for creating a Modal or Modeless dialog box
+    ../winsrc/ttwinspace.cpp      # Windows-only ttlib namespace functions

--- a/src/wxwin32/.srcfiles.yaml
+++ b/src/wxwin32/.srcfiles.yaml
@@ -27,7 +27,7 @@ Files:
     ../ttcview.cpp      # string_view functionality on a zero-terminated char string.
     ../ttlibspace.cpp   # ttlib namespace functions
     ../ttmultistr.cpp   # ttlib::multistr, ttlib::multiview
-    # ../ttparser.cpp     # Command line parser
+    ../ttparser.cpp     # Command line parser
     ../ttstr.cpp        # Enhanced version of wxString
     ../ttstrings.cpp    # Class for handling zero-terminated char strings.
     ../ttsvector.cpp    # Vector class for storing ttString strings

--- a/src/wxwin32/pch.cpp
+++ b/src/wxwin32/pch.cpp
@@ -1,0 +1,3 @@
+// Thie file is used to create a pre-compiled header for use in the entire project (required by MSVC)
+
+#include "pch.h"


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Closes #219 

This adds a 32-bit directory for building ttLibwx32.lib, and fixes the build error in ttparser.cpp.