### PR TITLE
Replace calls to u8path and u8string

### DIFF
--- a/src/ttcview.cpp
+++ b/src/ttcview.cpp
@@ -345,7 +345,11 @@ bool cview::file_exists() const
 {
     if (empty())
         return false;
-    auto file = std::filesystem::directory_entry(std::filesystem::u8path(c_str()));
+#ifdef _MSC_VER
+    auto file = std::filesystem::directory_entry(std::filesystem::path((to_utf16())));
+#else
+    auto file = std::filesystem::directory_entry(std::filesystem::path(c_str()));
+#endif
     return (file.exists() && !file.is_directory());
 }
 
@@ -353,7 +357,11 @@ bool cview::dir_exists() const
 {
     if (empty())
         return false;
-    auto file = std::filesystem::directory_entry(std::filesystem::u8path(c_str()));
+#ifdef _MSC_VER
+    auto file = std::filesystem::directory_entry(std::filesystem::path(to_utf16()));
+#else
+    auto file = std::filesystem::directory_entry(std::filesystem::path(c_str()));
+#endif
     return (file.exists() && file.is_directory());
 }
 
@@ -378,10 +386,10 @@ size_t cview::find_oneof(const std::string& set) const
 {
     if (set.empty())
         return tt::npos;
-    const char* pszFound = std::strpbrk(c_str(), set.c_str());
-    if (!pszFound)
+    auto pFound = std::strpbrk(c_str(), set.c_str());
+    if (!pFound)
         return tt::npos;
-    return (static_cast<size_t>(pszFound - c_str()));
+    return (static_cast<size_t>(pFound - c_str()));
 }
 
 size_t cview::find_oneof(cview set, size_t start) const
@@ -389,20 +397,20 @@ size_t cview::find_oneof(cview set, size_t start) const
     if (set.empty())
         return tt::npos;
     auto view_start = subview(start);
-    const char* pszFound = std::strpbrk(view_start, set);
-    if (!pszFound)
+    auto pFound = std::strpbrk(view_start, set);
+    if (!pFound)
         return tt::npos;
-    return (static_cast<size_t>(pszFound - view_start.c_str()));
+    return (static_cast<size_t>(pFound - view_start.c_str()));
 }
 
 size_t cview::find_space(size_t start) const
 {
     if (start >= length())
         return npos;
-    const char* pszFound = std::strpbrk(c_str() + start, " \t\r\n\f");
-    if (!pszFound)
+    auto pFound = std::strpbrk(c_str() + start, " \t\r\n\f");
+    if (!pFound)
         return npos;
-    return (static_cast<size_t>(pszFound - c_str()));
+    return (static_cast<size_t>(pFound - c_str()));
 }
 
 size_t cview::find_nonspace(size_t start) const


### PR DESCRIPTION
Closes #224

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR conditionalizes the calls in ttlib::cstr and ttlib::cview that deal with std::filesystem::path. In C++17, the standards committee introduced u8path() and u8string() to provide UTF8 conversion for the UTF16 strings that are used in the Microsoft implementation on Windows. Unfortunately, the return value was changed from std::string to std::u8string in C++20. This breaks any code that expected std::string.

The fix for this is to replace the calls to u8path() and u8string() with our own utf8/utf16 conversion code that we already had. This requires putting the code in conditional sections which is unfortunate, but we only need to do the UTF8/UTF16 conversion when compiling with MSVC.