### PR TITLE
Fix make_relative() and make_absolute()

### DIFF
--- a/src/ttcstr.cpp
+++ b/src/ttcstr.cpp
@@ -624,7 +624,7 @@ cstr& cstr::make_relative(ttlib::cview relative_to)
     auto current = std::filesystem::absolute(std::filesystem::path(to_utf16()));
     auto rel_to = std::filesystem::absolute(std::filesystem::path(relative_to.to_utf16()));
     clear();
-    utf16to8(current.lexically_relative(rel_to).c_str());
+    ttlib::utf16to8(current.lexically_relative(rel_to).wstring(), *this);
 #else
     auto current = std::filesystem::absolute(std::filesystem::path(c_str()));
     auto rel_to = std::filesystem::absolute(std::filesystem::path(relative_to.c_str()));
@@ -640,7 +640,7 @@ cstr& cstr::make_absolute()
 #ifdef _MSC_VER
         auto current = std::filesystem::path(to_utf16());
         clear();
-        utf16to8(std::filesystem::absolute(current).c_str());
+        ttlib::utf16to8(std::filesystem::absolute(current).wstring(), *this);
 #else
         auto current = std::filesystem::path(c_str());
         assign(std::filesystem::absolute(current).string());


### PR DESCRIPTION
Call fs::path.wstring() not fs::path.c_str(), use more efficient version of utf16to8().

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
`make_relative()` and `make_absolute()` were broken when I replaced the `u8path()` code. This update correctly retrieves the wide string when compiled for `_MSC_VER` and optimizes the conversion from utf16 to utf8.