### PR TITLE
Add enum to cwd class for clarity

### DIFF
--- a/include/ttcwd.h
+++ b/include/ttcwd.h
@@ -19,8 +19,14 @@ namespace ttlib
     class cwd : public ttlib::cstr
     {
     public:
+        enum : bool
+        {
+            no_restore = false,
+            restore = true
+        };
+
         // Specify true to restore the directory in the destructor
-        cwd(bool restore = false)
+        cwd(bool restore = cwd::no_restore)
         {
             assignCwd();
             if (restore)


### PR DESCRIPTION
Closes #162

These need to be handled on a case-by-case basis. For more lengthy classes, the enum can actually make it harder to read, particularly when using IntelliSense that will show the comment about what the parameter is for.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
