### PR TITLE
Add optional trim param to multistr/multiview

### DIFF
--- a/include/ttlibspace.h
+++ b/include/ttlibspace.h
@@ -87,7 +87,8 @@ namespace tt
     {
         right,
         left,
-        both
+        both,
+        none
     };
 
 }  // namespace tt

--- a/include/ttmultistr.h
+++ b/include/ttmultistr.h
@@ -29,14 +29,14 @@ namespace ttlib
     public:
         multistr() {}
 
-        multistr(std::string_view str, char separator = ';') { SetString(str, separator); }
+        multistr(std::string_view str, char separator = ';', tt::TRIM trim = tt::TRIM::none) { SetString(str, separator, trim); }
 
         // Use this when a character sequence (such as "/r/n") separates the substrings
-        multistr(std::string_view str, std::string_view separator) { SetString(str, separator); }
+        multistr(std::string_view str, std::string_view separator, tt::TRIM trim = tt::TRIM::none) { SetString(str, separator, trim); }
 
         // Clears the current vector of parsed strings and creates a new vector
-        void SetString(std::string_view str, char separator = ';');
-        void SetString(std::string_view str, std::string_view separator);
+        void SetString(std::string_view str, char separator = ';', tt::TRIM trim = tt::TRIM::none);
+        void SetString(std::string_view str, std::string_view separator, tt::TRIM trim = tt::TRIM::none);
     };
 
     class multiview : public std::vector<ttlib::sview>
@@ -45,13 +45,13 @@ namespace ttlib
         // Similar to multistr, only the vector consists of views into the original string
         multiview() {}
 
-        multiview(std::string_view str, char separator = ';') { SetString(str, separator); }
+        multiview(std::string_view str, char separator = ';', tt::TRIM trim = tt::TRIM::none) { SetString(str, separator, trim); }
 
         // Use this when a character sequence (such as "/r/n") separates the substrings
-        multiview(std::string_view str, std::string_view separator) { SetString(str, separator); }
+        multiview(std::string_view str, std::string_view separator, tt::TRIM trim = tt::TRIM::none) { SetString(str, separator, trim); }
 
         // Clears the current vector of parsed strings and creates a new vector
-        void SetString(std::string_view str, char separator = ';');
-        void SetString(std::string_view str, std::string_view separator);
+        void SetString(std::string_view str, char separator = ';', tt::TRIM trim = tt::TRIM::none);
+        void SetString(std::string_view str, std::string_view separator, tt::TRIM trim = tt::TRIM::none);
     };
 }  // namespace ttlib

--- a/src/ttmultistr.cpp
+++ b/src/ttmultistr.cpp
@@ -12,76 +12,260 @@
 
 using namespace ttlib;
 
-void multistr::SetString(std::string_view str, char separator)
+void multistr::SetString(std::string_view str, char separator, tt::TRIM trim)
 {
     clear();
     size_t start = 0;
     size_t end = str.find_first_of(separator);
-    while (end != std::string_view::npos)
+
+    // The last string will not have a separator, so end == tt::npos, but we still need to add that final string
+    for (;;)
     {
         emplace_back();
-        back().assign(str.substr(start, end - start));
+        if (trim == tt::TRIM::both || trim == tt::TRIM::left)
+        {
+            auto begin = str.find_first_not_of(" \t\n\r\f\v", start);
+            if (begin != tt::npos)
+            {
+                start = begin;
+            }
+            else
+            {
+                if (end != tt::npos)
+                {
+                    start = end;
+                }
+                else
+                {
+                    // We're at the end, there's nothing here but whitespace, so we're done
+                    break;
+                }
+            }
+        }
+
+        if (trim == tt::TRIM::both || trim == tt::TRIM::right)
+        {
+            auto temp_end = end;
+            if (end == tt::npos)
+                temp_end = str.length() - start;
+            while (temp_end > start && ttlib::is_whitespace(str.at(temp_end - 1)))
+            {
+                --temp_end;
+            }
+            back().assign(str.substr(start, temp_end - start));
+        }
+
+        else if (end == tt::npos)
+        {
+            back().assign(str.substr(start, str.length() - start));
+        }
+        else
+        {
+            back().assign(str.substr(start, end - start));
+        }
+
+        // The last string will not have a separator after it so end will already be set to tt::npos
+        if (end == tt::npos)
+            break;
 
         start = end + sizeof(char);
         if (start >= str.length())
-            return;
+            break;
+
         end = str.find_first_of(separator, start);
     }
-    emplace_back();
-    back().assign(str.substr(start));
 }
 
-void multistr::SetString(std::string_view str, std::string_view separator)
+void multistr::SetString(std::string_view str, std::string_view separator, tt::TRIM trim)
 {
     clear();
     size_t start = 0;
     size_t end = str.find_first_of(separator);
-    while (end != std::string_view::npos)
+
+    // The last string will not have a separator, so end == tt::npos, but we still need to add that final string
+    for (;;)
     {
         emplace_back();
-        back().assign(str.substr(start, end - start));
+        if (trim == tt::TRIM::both || trim == tt::TRIM::left)
+        {
+            auto begin = str.find_first_not_of(" \t\n\r\f\v", start);
+            if (begin != tt::npos)
+            {
+                start = begin;
+            }
+            else
+            {
+                if (end != tt::npos)
+                {
+                    start = end;
+                }
+                else
+                {
+                    // We're at the end, there's nothing here but whitespace, so we're done
+                    break;
+                }
+            }
+        }
 
-        start = end + separator.size();
+        if (trim == tt::TRIM::both || trim == tt::TRIM::right)
+        {
+            auto temp_end = end;
+            if (end == tt::npos)
+                temp_end = str.length() - start;
+            while (temp_end > start && ttlib::is_whitespace(str.at(temp_end - 1)))
+            {
+                --temp_end;
+            }
+            back().assign(str.substr(start, temp_end - start));
+        }
+
+        else if (end == tt::npos)
+        {
+            back().assign(str.substr(start, str.length() - start));
+        }
+        else
+        {
+            back().assign(str.substr(start, end - start));
+        }
+
+        // The last string will not have a separator after it so end will already be set to tt::npos
+        if (end == tt::npos)
+            break;
+
+        start = end + separator.length();
         if (start >= str.length())
-            return;
+            break;
+
         end = str.find_first_of(separator, start);
     }
-    emplace_back();
-    back().assign(str.substr(start));
 }
 
 /////////////////////////////////////// multiview ///////////////////////////////////////
 
-void multiview::SetString(std::string_view str, char separator)
+void multiview::SetString(std::string_view str, char separator, tt::TRIM trim)
 {
     clear();
     size_t start = 0;
     size_t end = str.find_first_of(separator);
-    while (end != std::string_view::npos)
+
+    // The last string will not have a separator, so end == tt::npos, but we still need to add that final string
+    for (;;)
     {
-        push_back(str.substr(start, end - start));
+        emplace_back(ttlib::emptystring);
+        if (trim == tt::TRIM::both || trim == tt::TRIM::left)
+        {
+            auto begin = str.find_first_not_of(" \t\n\r\f\v", start);
+            if (begin != tt::npos)
+            {
+                start = begin;
+            }
+            else
+            {
+                if (end != tt::npos)
+                {
+                    start = end;
+                }
+                else
+                {
+                    // We're at the end, there's nothing here but whitespace, so we're done
+                    break;
+                }
+            }
+        }
+
+        if (trim == tt::TRIM::both || trim == tt::TRIM::right)
+        {
+            auto temp_end = end;
+            if (end == tt::npos)
+                temp_end = str.length() - start;
+            while (temp_end > start && ttlib::is_whitespace(str.at(temp_end - 1)))
+            {
+                --temp_end;
+            }
+            back() = str.substr(start, temp_end - start);
+        }
+
+        else if (end == tt::npos)
+        {
+            back() = str.substr(start, str.length() - start);
+        }
+        else
+        {
+            back() = str.substr(start, end - start);
+        }
+
+        // The last string will not have a separator after it so end will already be set to tt::npos
+        if (end == tt::npos)
+            break;
 
         start = end + sizeof(char);
         if (start >= str.length())
-            return;
+            break;
+
         end = str.find_first_of(separator, start);
     }
-    push_back(str.substr(start));
 }
 
-void multiview::SetString(std::string_view str, std::string_view separator)
+void multiview::SetString(std::string_view str, std::string_view separator, tt::TRIM trim)
 {
     clear();
     size_t start = 0;
     size_t end = str.find_first_of(separator);
-    while (end != std::string_view::npos)
-    {
-        push_back(str.substr(start, end - start));
 
-        start = end + separator.size();
+    // The last string will not have a separator, so end == tt::npos, but we still need to add that final string
+    for (;;)
+    {
+        emplace_back(ttlib::emptystring);
+        if (trim == tt::TRIM::both || trim == tt::TRIM::left)
+        {
+            auto begin = str.find_first_not_of(" \t\n\r\f\v", start);
+            if (begin != tt::npos)
+            {
+                start = begin;
+            }
+            else
+            {
+                if (end != tt::npos)
+                {
+                    start = end;
+                }
+                else
+                {
+                    // We're at the end, there's nothing here but whitespace, so we're done
+                    break;
+                }
+            }
+        }
+
+        if (trim == tt::TRIM::both || trim == tt::TRIM::right)
+        {
+            auto temp_end = end;
+            if (end == tt::npos)
+                temp_end = str.length() - start;
+            while (temp_end > start && ttlib::is_whitespace(str.at(temp_end - 1)))
+            {
+                --temp_end;
+            }
+            back() = str.substr(start, temp_end - start);
+        }
+
+        else if (end == tt::npos)
+        {
+            back() = str.substr(start, str.length() - start);
+        }
+        else
+        {
+            back() = str.substr(start, end - start);
+        }
+
+        // The last string will not have a separator after it so end will already be set to tt::npos
+        if (end == tt::npos)
+            break;
+
+        start = end + separator.length();
         if (start >= str.length())
-            return;
+            break;
+
         end = str.find_first_of(separator, start);
     }
-    push_back(str.substr(start));
 }


### PR DESCRIPTION
Closes #248

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Adding the third parameter with a default value makes it compatible with existing code. Adding the trim parameter increases the cases where multiview can be used instead of multistr, removing the need for memory allocation and string copying that multistr requires.