### PR TITLE
Change ttlib::viewfile to use a vector of ttlib::sview

### DIFF
--- a/include/tttextfile.h
+++ b/include/tttextfile.h
@@ -35,7 +35,8 @@
 #include <string_view>
 #include <vector>
 
-#include "ttcstr.h"
+#include "ttcstr.h"   // cstr -- std::string with additional methods
+#include "ttsview.h"  // sview -- std::string_view with additional methods
 
 namespace ttlib
 {
@@ -147,9 +148,9 @@ namespace ttlib
 namespace ttlib
 {
     /// Almost identical to ttlib::textfile, only the entire file is stored as a single
-    /// string, and the vector contains a std::string_view for each line. This is
-    /// a faster way to read the file if you don't need to modify the contents.
-    class viewfile : public std::vector<std::string_view>
+    /// string, and the vector contains a ttlib::sview (std::string_view) for each line. This
+    /// is a faster way to read the file if you don't need to modify the contents.
+    class viewfile : public std::vector<ttlib::sview>
     {
     public:
         /// Reads a line-oriented file and converts each line into a std::string.


### PR DESCRIPTION
Since ttlib::sview is just std::string_view with additional methods, this simply adds more functionality without affecting any code that was expecting std::string_view.

Closes #257

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR simpley changes the `viewfile` class to use a vector of sview instead of string_view (sview is simply string_view with additional methods).
