### PR TITLE
Add moveto_substr()

### DIFF
--- a/include/ttsview.h
+++ b/include/ttsview.h
@@ -194,6 +194,13 @@ namespace ttlib
         /// sview.
         bool moveto_filename() noexcept;
 
+        /// Move start position to the substr in the current string, returning true if
+        /// found.
+        ///
+        /// If StepOverIfFound is true, start position is set to the first non-whitespace
+        /// character found after substr.
+        bool moveto_substr(std::string_view substr, bool StepOverIfFound = false) noexcept;
+
         bool operator==(ttlib::sview str) { return this->is_sameas(str); }
     };
 }  // namespace ttlib

--- a/src/ttsview.cpp
+++ b/src/ttsview.cpp
@@ -292,6 +292,26 @@ bool sview::moveto_filename() noexcept
     return true;
 }
 
+bool sview::moveto_substr(std::string_view substr, bool StepOverIfFound) noexcept
+{
+    auto pos = find(substr);
+    if (!ttlib::is_found(pos))
+    {
+        return false;
+    }
+
+    if (StepOverIfFound)
+    {
+        auto stepover_pos = find_nonspace(pos + substr.size());
+        if (ttlib::is_found(pos))
+        {
+            pos = stepover_pos;
+        }
+    }
+    remove_prefix(pos);
+    return true;
+}
+
 ttlib::sview sview::extension() const noexcept
 {
     if (empty())


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR adds a `moveto_substr()` method to the `ttlib::sview` class.

Closes #258