### PR TITLE
Add CreateSubString() function

### DIFF
--- a/include/ttcstr.h
+++ b/include/ttcstr.h
@@ -212,6 +212,12 @@ namespace ttlib
         /// ending character was found.
         size_t ExtractSubString(std::string_view src, size_t offset = 0);
 
+        /// Identical to ExtractSubString only it returns ttlib::cstr& instead of a size_t
+        ttlib::cstr& CreateSubString(std::string_view src, size_t offset = 0) {
+            ExtractSubString(src, offset);
+            return *this;
+        }
+
         /// Replace first (or all) occurrences of substring with another one
         size_t Replace(std::string_view oldtext, std::string_view newtext, bool replace_all = tt::REPLACE::once,
                        tt::CASE checkcase = tt::CASE::exact);

--- a/include/ttcstr.h
+++ b/include/ttcstr.h
@@ -213,7 +213,8 @@ namespace ttlib
         size_t ExtractSubString(std::string_view src, size_t offset = 0);
 
         /// Identical to ExtractSubString only it returns ttlib::cstr& instead of a size_t
-        ttlib::cstr& CreateSubString(std::string_view src, size_t offset = 0) {
+        ttlib::cstr& CreateSubString(std::string_view src, size_t offset = 0)
+        {
             ExtractSubString(src, offset);
             return *this;
         }


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR creates a header-only `CreateSubString()` method for `ttlib::cstr`. All it does is call `ExtractSubString()` but returns `*this` instead of `size_t'.

Closes #260