### PR TITLE
Adds trim() and erase_from() methods to ttlib::sview

### DIFF
--- a/include/ttcstr.h
+++ b/include/ttcstr.h
@@ -158,11 +158,11 @@ namespace ttlib
         int atoi(size_t start = 0) const { return ttlib::atoi(c_str() + start); }
 
         /// If character is found, line is truncated from the character on, and then
-        /// any trailing space is removed;
+        /// any trailing space is removed.
         void erase_from(char ch);
 
         /// If string is found, line is truncated from the string on, and then
-        /// any trailing space is removed;
+        /// any trailing space is removed.
         void erase_from(std::string_view sub);
 
         /// Removes whitespace: ' ', \t, \r, \\n, \f

--- a/include/ttsview.h
+++ b/include/ttsview.h
@@ -125,6 +125,15 @@ namespace ttlib
         /// Returns true if the current string refers to an existing directory.
         bool dir_exists() const;
 
+        /// If string is found, line is truncated from the string on, and then
+        /// any trailing space is removed.
+        sview& erase_from(std::string_view sub, tt::CASE check = tt::CASE::exact);
+
+        /// Removes whitespace: ' ', \t, \r, \\n, \f
+        ///
+        /// where: TRIM::right, TRIM::left, or TRIM::both
+        sview& trim(tt::TRIM where = tt::TRIM::right);
+
         /// Unlike substr(), this will not throw an exception if start is out of range.
         sview subview(size_t start = 0) const
         {

--- a/src/ttsview.cpp
+++ b/src/ttsview.cpp
@@ -580,3 +580,58 @@ sview sview::stepover(std::string_view str) noexcept
     else
         return sview(str.data() + pos, str.length() - pos);
 }
+
+sview& sview::trim(tt::TRIM where)
+{
+    if (empty())
+        return *this;
+
+    if (where == tt::TRIM::right || where == tt::TRIM::both)
+    {
+        auto len = length();
+        for (--len; len != std::string::npos; --len)
+        {
+            // char ch = at(len);
+            char ch = data()[len];
+            if (ch != ' ' && ch != '\t' && ch != '\r' && ch != '\n' && ch != '\f')
+            {
+                ++len;
+                break;
+            }
+        }
+
+        if (len < length())
+            remove_suffix(length() - len);
+    }
+
+    // If trim(right) was called above, the string may now be empty -- front() fails on an empty string
+    if (!empty() && (where == tt::TRIM::left || where == tt::TRIM::both))
+    {
+        // Assume that most strings won't start with whitespace, so return as quickly as possible if that is the
+        // case.
+        if (!ttlib::is_whitespace(front()))
+            return *this;
+
+        size_t pos;
+        for (pos = 1; pos < length(); ++pos)
+        {
+            if (!ttlib::is_whitespace(data()[pos]))
+                break;
+        }
+        remove_prefix(pos);
+    }
+
+    return *this;
+}
+
+sview& sview::erase_from(std::string_view sub, tt::CASE check)
+{
+    auto pos = locate(sub, 0, check);
+    if (pos != tt::npos)
+    {
+        remove_suffix(length() - pos);
+        trim();
+    }
+
+    return *this;
+}


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This essentially match the functions of the same name in ttlib::cstr.