### PR TITLE
Call OutputDebugString in addition to the messagebox

### DIFF
--- a/src/winsrc/ttdebug.cpp
+++ b/src/winsrc/ttdebug.cpp
@@ -45,6 +45,16 @@ bool ttAssertionMsg(const char* filename, const char* function, int line, const 
     std::unique_lock<std::mutex> classLock(ttdbg::mutexAssert);
 
     ttlib::cstr str;
+    // Start by creating a string to send to the debugger
+    if (cond)
+        str << "Expression: " << cond << "\n";
+    if (!msg.empty())
+        str << "Comment: " << msg << "\n";
+    str << filename << '(' << line << ')' << "\n";
+    str << "Function: " << function << "\n";
+    OutputDebugStringW(str.to_utf16().c_str());
+    str.clear();
+
     if (cond)
         str << "Expression: " << cond << "\n\n";
     if (!msg.empty())

--- a/src/winsrc/ttdebug_min.cpp
+++ b/src/winsrc/ttdebug_min.cpp
@@ -27,6 +27,16 @@ bool ttAssertionMsg(const char* filename, const char* function, int line, const 
     std::unique_lock<std::mutex> classLock(ttdbg::mutexAssert);
 
     ttlib::cstr str;
+    // Start by creating a string to send to the debugger
+    if (cond)
+        str << "Expression: " << cond << "\n";
+    if (!msg.empty())
+        str << "Comment: " << msg << "\n";
+    str << filename << '(' << line << ')' << "\n";
+    str << "Function: " << function << "\n";
+    OutputDebugStringW(str.to_utf16().c_str());
+    str.clear();
+
     if (cond)
         str << "Expression: " << cond << "\n\n";
     if (!msg.empty())


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
This PR expands the Windows-only `ttAssertionMsg()` in both the full and minimal modules. The assertion call now also formats a message and calls `OutputDebugString()`. For Visual Studio Code users, this will send the message to the Debug Console making it possible to see what the assertion (and optional comment) was as well as a link to the file that caused the problem.
