### PR TITLE
Ignore invalid UTF8 sequence

### DIFF
--- a/src/ttlibspace.cpp
+++ b/src/ttlibspace.cpp
@@ -568,23 +568,32 @@ void ttlib::utf8to16(std::string_view str, std::wstring& dest)
             uint32_t val = (str[pos] & 0xFF);
             if ((UINT8(str[pos]) >> 5) == 6)
             {
-                assert(pos + 1 < str.size());
-                val = ((val << 6) & 0x7FF) + (str[++pos] & 0x3F);
+                assertm(pos + 1 < str.size(), "Invalid UTF8 string");
+                if (pos + 1 < str.size())
+                {
+                    val = ((val << 6) & 0x7FF) + (str[++pos] & 0x3F);
+                }
             }
 
             else if ((UINT8(str[pos]) >> 4) == 14)
             {
-                assert(pos + 2 < str.size());
-                val = ((val << 12) & 0xFFFF) + ((str[++pos] << 6) & 0xFFF);
-                val += (str[++pos] & 0x3F);
+                assertm(pos + 2 < str.size(), "Invalid UTF8 string");
+                if (pos + 2 < str.size())
+                {
+                    val = ((val << 12) & 0xFFFF) + ((str[++pos] << 6) & 0xFFF);
+                    val += (str[++pos] & 0x3F);
+                }
             }
 
             else if ((UINT8(str[pos]) >> 3) == 30)
             {
-                assert(pos + 3 < str.size());
-                val = ((val << 18) & 0x1FFFFF) + ((str[++pos] << 12) & 0x3FFFF);
-                val += (str[++pos] << 6) & 0xFFF;
-                val += (str[++pos] & 0x3F);
+                assertm(pos + 3 < str.size(), "Invalid UTF8 string");
+                if (pos + 3 < str.size())
+                {
+                    val = ((val << 18) & 0x1FFFFF) + ((str[++pos] << 12) & 0x3FFFF);
+                    val += (str[++pos] << 6) & 0xFFF;
+                    val += (str[++pos] & 0x3F);
+                }
             }
             else
             {


### PR DESCRIPTION
This will most likely occur under Windows when a non-UTF8 codepage is used and it contains codes that look like a UTF8 sequence.

Closes #265

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
Note that the returned string will _not_ be valid. It's the caller's responsibility to no pass in an invalid UTF8 string.