### PR TITLE
Optimize Replace when old/new string is the same length

### DIFF
--- a/src/ttcstr.cpp
+++ b/src/ttcstr.cpp
@@ -318,8 +318,18 @@ size_t cstr::Replace(std::string_view oldtext, std::string_view newtext, bool re
     {
         do
         {
-            erase(pos, oldtext.length());
-            insert(pos, newtext);
+            if (oldtext.size() == newtext.size())
+            {
+                for (size_t idx = 0; idx < newtext.size(); ++idx)
+                {
+                    data()[pos + idx] = newtext[idx];
+                }
+            }
+            else
+            {
+                erase(pos, oldtext.length());
+                insert(pos, newtext);
+            }
             ++replacements;
             pos += newtext.length();
             if (pos >= size() || !replace_all)

--- a/src/winsrc/ttdib.cpp
+++ b/src/winsrc/ttdib.cpp
@@ -275,7 +275,7 @@ BYTE ttCDib::GetNearestIndex(RGBQUAD c)
     long distance = 200000;
     BYTE i, j = 0;
     long k, l;
-    for (i = 0, l = 0; i < m_nColors; i++, l += sizeof(RGBQUAD))
+    for (i = 0, l = 0; i < static_cast<BYTE>(m_nColors & 0xFF); i++, l += sizeof(RGBQUAD))
     {
         k = (iDst[l] - c.rgbBlue) * (iDst[l] - c.rgbBlue) + (iDst[l + 1] - c.rgbGreen) * (iDst[l + 1] - c.rgbGreen) +
             (iDst[l + 2] - c.rgbRed) * (iDst[l + 2] - c.rgbRed);


### PR DESCRIPTION
<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
If the strings are the same length, then the replacement can be made directly in the rather then erase/insert which entail moving the entire string.