### PR TITLE
Add set_filename in case ReadFile was not called

### DIFF
--- a/include/tttextfile.h
+++ b/include/tttextfile.h
@@ -55,6 +55,9 @@ namespace ttlib
         /// This will be the filename passed to ReadFile()
         ttlib::cstr& filename() { return m_filename; }
 
+        /// Call this if ReadFile() was not used and you need to store a filename.
+        void set_filename(std::string_view filename) { m_filename = filename; }
+
         /// Reads a string as if it was a file (see ReadFile).
         void ReadString(std::string_view str);
 
@@ -158,6 +161,9 @@ namespace ttlib
 
         /// This will be the filename passed to ReadFile()
         ttlib::cstr& filename() { return m_filename; }
+
+        /// Call this if ReadFile() was not used and you need to store a filename.
+        void set_filename(std::string_view filename) { m_filename = filename; }
 
         /// Reads a string as if it was a file (see ReadFile).
         void ReadString(std::string_view str);


### PR DESCRIPTION
The isUnix app needed to store the filename to retrieve in a thread, but did not call ReadFile. This header-only function allowed for setting a filename without having to pass it separately to the thread.

<!--
    - Please provide enough information so that others can review your pull request.
    - If the PR fixes an issue, put "Closes #XXXX" in your comment to auto-close the issue that you have fixed.
    - Please run clang-format on the code BEFORE committing to avoid differences based solely on formatting.
-->
